### PR TITLE
SD-45: Add software versions to Slack hook

### DIFF
--- a/.github/workflows/community-showcase.yml
+++ b/.github/workflows/community-showcase.yml
@@ -56,19 +56,19 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        pipeline: 
-          - { 
-              name: rnaseq, 
-              url: nf-core-rnaseq, 
-              latest: true, 
-              profiles: "test" 
-          }
+        pipeline:
+          - {
+              name: rnaseq,
+              url: nf-core-rnaseq,
+              latest: true,
+              profiles: "test",
+            }
           - {
               name: viralrecon-illumina,
               url: nf-core-viralrecon,
               latest: true,
               profiles: "test",
-          }
+            }
         compute_env:
           - {
               name: community-showcase,
@@ -77,143 +77,142 @@ jobs:
               workspace_id: 40230138858677,
             }
 
-            steps:
-              - name: "export unique run name"
-                run: |
-                  set -euo pipefail
-                  echo "name=${{ matrix.pipeline.name }}_${{ matrix.compute_env.name }}_${{ needs.getdate.outputs.date }}_$(uuidgen | cut -c 1-8)" >> $GITHUB_OUTPUT
-                  echo "workspace=${{ matrix.compute_env.workspace_id }}" >> $GITHUB_OUTPUT
-                id: id
-        
-              - uses: seqeralabs/action-tower-launch@v2
-                if: ${{ !inputs.dryrun }}
-                id: submit-pipeline
-                with:
-                  pipeline: ${{ matrix.pipeline.url }}
-                  workspace_id: ${{ steps.id.outputs.workspace }}
-                  access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
-                  compute_env: ${{ matrix.compute_env.ref }}
-                  workdir: "${{ matrix.compute_env.workdir }}/work/${{ matrix.pipeline.name }}/work-${{ needs.getdate.outputs.date }}"
-                  run_name: "${{ steps.id.outputs.name }}"
-                  profiles: ${{ matrix.pipeline.profiles }}
-                  wait: SUBMITTED
-                  parameters: |
-                    {
-                        "outdir": "${{ matrix.compute_env.workdir }}/${{ matrix.pipeline.name }}/results-test-${{ needs.getdate.outputs.date }}"
-                    }
-        
-              - name: "Store run details as artifact"
-                if: success()
-                run: |
-                  set -euo pipefail
-                  echo ${{ steps.submit-pipeline.outputs.json }} | jq -r '. += { "pipeline": "${{ matrix.pipeline.name }}_${{ matrix.compute_env.name }}" }' \
-                    >> ${{ steps.id.outputs.name }}_${{ steps.id.outputs.workspace }}_${{ needs.getdate.outputs.date }}.json
-        
-              - uses: actions/upload-artifact@v3
-                if: success() || failure()
-                with:
-                  name: ${{ needs.getdate.outputs.date }}_run_details
-                  path: "${{ steps.id.outputs.name }}_${{ steps.id.outputs.workspace }}_${{ needs.getdate.outputs.date }}.json"
-        
-              - uses: actions/upload-artifact@v3
-                if: success() || failure()
-                with:
-                  name: ${{ needs.getdate.outputs.date }}_launch_log
-                  path: tower_action_*.log
-        
-          checkmatrix:
-            runs-on: ubuntu-latest
-            needs: [runtest, getdate]
-            continue-on-error: true
-            outputs:
-              matrix: ${{ steps.matrix.outputs.matrix }}
-            steps:
-              - uses: actions/download-artifact@v3
-                with:
-                  name: ${{ needs.getdate.outputs.date }}_run_details
-                  path: run_details
-        
-              - name: "stage matrix"
-                run: |
-                  set -euo pipefail
-                  echo "matrix=$(cat run_details/* | jq -c --slurp .)" >> $GITHUB_OUTPUT
-                id: matrix
-        
-          checkrun:
-            name: check.${{ matrix.includes.pipeline }}.${{ matrix.includes.workspaceId }}
-            runs-on: ubuntu-latest
-            needs: [getdate, checkmatrix]
-            continue-on-error: true
-            environment: ${{ inputs.timer || 'delay360mins' }}
-            env:
-              TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
-              TOWER_WORKSPACE_ID: ${{ matrix.includes.workspaceId }}
-            strategy:
-              matrix:
-                includes: ${{ fromJSON(needs.checkmatrix.outputs.matrix) }}
-        
-            steps:
-              - name: "print matrix input"
-                run: |
-                  set -euo pipefail
-                  echo "${{ toJSON(matrix) }}"
-        
-              - name: Install tw CLI
-                run: |
-                  set -euo pipefail
-                  wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.8.0/tw-linux-x86_64
-                  mv tw-* tw
-                  chmod +x tw
-                  sudo mv tw /usr/local/bin/
-        
-              - name: Get info
-                if: ${{ !inputs.dryrun }}
-                id: info
-                run: |
-                  set -euo pipefail
-                  tw -o json runs dump -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} --add-task-logs --add-fusion-logs --silent --output ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz
-                  tar -xzvf ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz
-                  tw -o json runs view -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} | jq -r '.general |= . + { "workspace": "${{ matrix.includes.workspaceRef }}", "pipeline": "${{ matrix.includes.pipeline }}", "url": "${{ matrix.includes.workflowUrl }}" }' > workflow-info.json
-                  jq -n 'reduce inputs as $s (.; (.[input_filename|rtrimstr(".json")]) += $s)' *.json > ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}_dump.json
-        
-              - uses: actions/upload-artifact@v3
-                with:
-                  name: ${{ needs.getdate.outputs.date }}_all_run_dumps
-                  path: "${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz"
-        
-              - uses: actions/upload-artifact@v3
-                with:
-                  name: ${{ needs.getdate.outputs.date }}_all_run_json
-                  path: "${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}_dump.json"
-        
-              - name: Clearup
-                if: ${{ (inputs.remove || true) && !inputs.dryrun }}
-                run: |
-                  set -euo pipefail
-                  STATUS=$(tw -o json runs view -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} | jq -r '.general.status')
-                  if [ "SUCCEEDED" = $STATUS ]; then
-                    # Won't delete if run is active
-                    tw -o json runs delete -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }}
-                  else
-                    echo "Run has not finished, delete with 'tw -o json runs delete -w ${{ matrix.includes.workspace }} -i ${{ matrix.includes.workflowId }}' when ready."
-                  fi
-        
-          slack:
-            runs-on: ubuntu-latest
-            needs: [getdate, checkrun]
-            steps:
-              - uses: actions/download-artifact@v3
-                with:
-                  name: ${{ needs.getdate.outputs.date }}_all_run_json
-                  path: runs
-        
-              - name: "Slack"
-                if: ${{ ( github.event_name != 'workflow_dispatch' && inputs.slack ) || true }}
-                run: |
-                  set -euo pipefail
-                  ls -1 runs/*
-                  cat runs/* | jq -r --slurp
-                  export MESSAGE=$(cat runs/* | jq -r --slurp '(["pipeline", "computeEnv", "workspace", "status", "platformVersion", "nextflowVersion", "pipelineRevision", "workflowUrl"] | (., map(length*"-"))), (.[] | [.["workflow-info"]["general"]["pipeline"], .["workflow-info"]["general"]["workspace"], .["workflow-launch"]["computeEnv"]["name"], .["workflow"]["status"], .["service-info"]["version"], .["workflow"]["nextflow"]["version"], .["workflow-launch"]["revision"], .["workflow-info"]["general"]["url"]]) | map(.//"-") | @tsv' | column -ts $'\t')
-                  echo $MESSAGE
-                  curl -X POST -H 'Content-type: application/json' --data "{'text': \"\`\`\`$MESSAGE\`\`\`\"}" ${{ secrets.SLACK_HOOK_URL }}
-        
+    steps:
+      - name: "export unique run name"
+        run: |
+          set -euo pipefail
+          echo "name=${{ matrix.pipeline.name }}_${{ matrix.compute_env.name }}_${{ needs.getdate.outputs.date }}_$(uuidgen | cut -c 1-8)" >> $GITHUB_OUTPUT
+          echo "workspace=${{ matrix.compute_env.workspace_id }}" >> $GITHUB_OUTPUT
+        id: id
+
+      - uses: seqeralabs/action-tower-launch@v2
+        if: ${{ !inputs.dryrun }}
+        id: submit-pipeline
+        with:
+          pipeline: ${{ matrix.pipeline.url }}
+          workspace_id: ${{ steps.id.outputs.workspace }}
+          access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
+          compute_env: ${{ matrix.compute_env.ref }}
+          workdir: "${{ matrix.compute_env.workdir }}/work/${{ matrix.pipeline.name }}/work-${{ needs.getdate.outputs.date }}"
+          run_name: "${{ steps.id.outputs.name }}"
+          profiles: ${{ matrix.pipeline.profiles }}
+          wait: SUBMITTED
+          parameters: |
+            {
+                "outdir": "${{ matrix.compute_env.workdir }}/${{ matrix.pipeline.name }}/results-test-${{ needs.getdate.outputs.date }}"
+            }
+
+      - name: "Store run details as artifact"
+        if: success()
+        run: |
+          set -euo pipefail
+          echo ${{ steps.submit-pipeline.outputs.json }} | jq -r '. += { "pipeline": "${{ matrix.pipeline.name }}_${{ matrix.compute_env.name }}" }' \
+            >> ${{ steps.id.outputs.name }}_${{ steps.id.outputs.workspace }}_${{ needs.getdate.outputs.date }}.json
+
+      - uses: actions/upload-artifact@v3
+        if: success() || failure()
+        with:
+          name: ${{ needs.getdate.outputs.date }}_run_details
+          path: "${{ steps.id.outputs.name }}_${{ steps.id.outputs.workspace }}_${{ needs.getdate.outputs.date }}.json"
+
+      - uses: actions/upload-artifact@v3
+        if: success() || failure()
+        with:
+          name: ${{ needs.getdate.outputs.date }}_launch_log
+          path: tower_action_*.log
+
+  checkmatrix:
+    runs-on: ubuntu-latest
+    needs: [runtest, getdate]
+    continue-on-error: true
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.getdate.outputs.date }}_run_details
+          path: run_details
+
+      - name: "stage matrix"
+        run: |
+          set -euo pipefail
+          echo "matrix=$(cat run_details/* | jq -c --slurp .)" >> $GITHUB_OUTPUT
+        id: matrix
+
+  checkrun:
+    name: check.${{ matrix.includes.pipeline }}.${{ matrix.includes.workspaceId }}
+    runs-on: ubuntu-latest
+    needs: [getdate, checkmatrix]
+    continue-on-error: true
+    environment: ${{ inputs.timer || 'delay360mins' }}
+    env:
+      TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
+      TOWER_WORKSPACE_ID: ${{ matrix.includes.workspaceId }}
+    strategy:
+      matrix:
+        includes: ${{ fromJSON(needs.checkmatrix.outputs.matrix) }}
+
+    steps:
+      - name: "print matrix input"
+        run: |
+          set -euo pipefail
+          echo "${{ toJSON(matrix) }}"
+
+      - name: Install tw CLI
+        run: |
+          set -euo pipefail
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.8.0/tw-linux-x86_64
+          mv tw-* tw
+          chmod +x tw
+          sudo mv tw /usr/local/bin/
+
+      - name: Get info
+        if: ${{ !inputs.dryrun }}
+        id: info
+        run: |
+          set -euo pipefail
+          tw -o json runs dump -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} --add-task-logs --add-fusion-logs --silent --output ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz
+          tar -xzvf ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz
+          tw -o json runs view -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} | jq -r '.general |= . + { "workspace": "${{ matrix.includes.workspaceRef }}", "pipeline": "${{ matrix.includes.pipeline }}", "url": "${{ matrix.includes.workflowUrl }}" }' > workflow-info.json
+          jq -n 'reduce inputs as $s (.; (.[input_filename|rtrimstr(".json")]) += $s)' *.json > ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}_dump.json
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ needs.getdate.outputs.date }}_all_run_dumps
+          path: "${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ needs.getdate.outputs.date }}_all_run_json
+          path: "${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}_dump.json"
+
+      - name: Clearup
+        if: ${{ (inputs.remove || true) && !inputs.dryrun }}
+        run: |
+          set -euo pipefail
+          STATUS=$(tw -o json runs view -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} | jq -r '.general.status')
+          if [ "SUCCEEDED" = $STATUS ]; then
+            # Won't delete if run is active
+            tw -o json runs delete -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }}
+          else
+            echo "Run has not finished, delete with 'tw -o json runs delete -w ${{ matrix.includes.workspace }} -i ${{ matrix.includes.workflowId }}' when ready."
+          fi
+
+  slack:
+    runs-on: ubuntu-latest
+    needs: [getdate, checkrun]
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.getdate.outputs.date }}_all_run_json
+          path: runs
+
+      - name: "Slack"
+        if: ${{ ( github.event_name != 'workflow_dispatch' && inputs.slack ) || true }}
+        run: |
+          set -euo pipefail
+          ls -1 runs/*
+          cat runs/* | jq -r --slurp
+          export MESSAGE=$(cat runs/* | jq -r --slurp '(["pipeline", "computeEnv", "workspace", "status", "platformVersion", "nextflowVersion", "pipelineRevision", "workflowUrl"] | (., map(length*"-"))), (.[] | [.["workflow-info"]["general"]["pipeline"], .["workflow-info"]["general"]["workspace"], .["workflow-launch"]["computeEnv"]["name"], .["workflow"]["status"], .["service-info"]["version"], .["workflow"]["nextflow"]["version"], .["workflow-launch"]["revision"], .["workflow-info"]["general"]["url"]]) | map(.//"-") | @tsv' | column -ts $'\t')
+          echo $MESSAGE
+          curl -X POST -H 'Content-type: application/json' --data "{'text': \"\`\`\`$MESSAGE\`\`\`\"}" ${{ secrets.SLACK_HOOK_URL }}

--- a/.github/workflows/community-showcase.yml
+++ b/.github/workflows/community-showcase.yml
@@ -77,133 +77,143 @@ jobs:
               workspace_id: 40230138858677,
             }
 
-    steps:
-      - name: "export unique run name"
-        run: |
-          set -euo pipefail
-          echo "name=${{ matrix.pipeline.name }}_${{ matrix.compute_env.name }}_${{ needs.getdate.outputs.date }}_$(uuidgen | cut -c 1-8)" >> $GITHUB_OUTPUT
-          echo "workspace=${{ matrix.compute_env.workspace_id }}" >> $GITHUB_OUTPUT
-        id: id
-
-      - uses: seqeralabs/action-tower-launch@v2
-        if: ${{ !inputs.dryrun }}
-        id: submit-pipeline
-        with:
-          pipeline: ${{ matrix.pipeline.url }}
-          workspace_id: ${{ steps.id.outputs.workspace }}
-          access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
-          compute_env: ${{ matrix.compute_env.ref }}
-          run_name: "${{ steps.id.outputs.name }}"
-          profiles: ${{ matrix.pipeline.profiles }}
-          wait: SUBMITTED
-          parameters: |
-            {
-                "outdir": "${{ matrix.compute_env.workdir }}/${{ matrix.pipeline.name }}/results-test-${{ needs.getdate.outputs.date }}"
-            }
-
-      - name: "Store run details as artifact"
-        if: success()
-        run: |
-          set -euo pipefail
-          echo ${{ steps.submit-pipeline.outputs.json }} | jq -r '. += { "pipeline": "${{ matrix.pipeline.name }}_${{ matrix.compute_env.name }}" }' \
-            >> ${{ steps.id.outputs.name }}_${{ steps.id.outputs.workspace }}_${{ needs.getdate.outputs.date }}.json
-
-      - uses: actions/upload-artifact@v3
-        if: success() || failure()
-        with:
-          name: ${{ needs.getdate.outputs.date }}_run_details
-          path: "${{ steps.id.outputs.name }}_${{ steps.id.outputs.workspace }}_${{ needs.getdate.outputs.date }}.json"
-
-      - uses: actions/upload-artifact@v3
-        if: success() || failure()
-        with:
-          name: ${{ matrix.pipeline.name }}_${{ matrix.compute_env.name }}_log
-          path: tower_action_*.log
-
-  checkmatrix:
-    runs-on: ubuntu-latest
-    needs: [runtest, getdate]
-    continue-on-error: true
-    outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: ${{ needs.getdate.outputs.date }}_run_details
-          path: run_details
-
-      - name: "stage matrix"
-        run: |
-          set -euo pipefail
-          echo "matrix=$(cat run_details/* | jq -c --slurp .)" >> $GITHUB_OUTPUT
-        id: matrix
-
-  checkrun:
-    name: check.${{ matrix.includes.pipeline }}.${{ matrix.includes.workspaceId }}
-    runs-on: ubuntu-latest
-    needs: [getdate, checkmatrix]
-    continue-on-error: true
-    environment: ${{ inputs.timer || 'delay360mins' }}
-    env:
-      TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
-      TOWER_WORKSPACE_ID: ${{ matrix.includes.workspaceId }}
-    strategy:
-      matrix:
-        includes: ${{ fromJSON(needs.checkmatrix.outputs.matrix) }}
-
-    steps:
-      - name: "print matrix input"
-        run: |
-          set -euo pipefail
-          echo "${{ toJSON(matrix) }}"
-
-      - name: Install tw CLI
-        run: |
-          set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.7.3/tw-0.7.3-linux-x86_64
-          mv tw-* tw
-          chmod +x tw
-          sudo mv tw /usr/local/bin/
-
-      - name: Get info
-        if: ${{ !inputs.dryrun }}
-        id: info
-        run: |
-          set -euo pipefail
-          tw -o json runs view -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} | jq -r '.general |= . + { "workspace": "${{ matrix.includes.workspaceRef }}", "pipeline": "${{ matrix.includes.pipeline }}", "url": "${{ matrix.includes.workflowUrl }}" }' > ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.json
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ needs.getdate.outputs.date }}_all_runs
-          path: "${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.json"
-
-      - name: Clearup
-        if: ${{ (inputs.remove || true) && !inputs.dryrun }}
-        run: |
-          set -euo pipefail
-          STATUS=$(tw -o json runs view -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} | jq -r '.general.status')
-          if [ "SUCCEEDED" = $STATUS ]; then
-            # Won't delete if run is active
-            tw -o json runs delete -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }}
-          else
-            echo "Run has not finished, delete with 'tw -o json runs delete -w ${{ matrix.includes.workspace }} -i ${{ matrix.includes.workflowId }}' when ready."
-          fi
-
-  slack:
-    runs-on: ubuntu-latest
-    needs: [getdate, checkrun]
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: ${{ needs.getdate.outputs.date }}_all_runs
-          path: runs
-
-      - name: "Slack"
-        if: ${{ ( github.event_name != 'workflow_dispatch' && inputs.slack ) || true }}
-        run: |
-          set -euo pipefail
-          ls -1 runs/*
-          cat runs/* | jq -r --slurp
-          export MESSAGE=$(cat runs/* | jq -r --slurp '(["pipeline", "computeEnv", "workspace", "status", "workflowUrl"] | (., map(length*"-"))), (.[] | [.general.pipeline, .general.computeEnv, .general.workspace, .general.status, .general.url]) | @tsv' | column -ts $'\t')
-          echo $MESSAGE
-          curl -X POST -H 'Content-type: application/json' --data "{'text': \"\`\`\`$MESSAGE\`\`\`\"}" ${{ secrets.SLACK_HOOK_URL }}
+            steps:
+              - name: "export unique run name"
+                run: |
+                  set -euo pipefail
+                  echo "name=${{ matrix.pipeline.name }}_${{ matrix.compute_env.name }}_${{ needs.getdate.outputs.date }}_$(uuidgen | cut -c 1-8)" >> $GITHUB_OUTPUT
+                  echo "workspace=${{ matrix.compute_env.workspace_id }}" >> $GITHUB_OUTPUT
+                id: id
+        
+              - uses: seqeralabs/action-tower-launch@v2
+                if: ${{ !inputs.dryrun }}
+                id: submit-pipeline
+                with:
+                  pipeline: ${{ matrix.pipeline.url }}
+                  workspace_id: ${{ steps.id.outputs.workspace }}
+                  access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
+                  compute_env: ${{ matrix.compute_env.ref }}
+                  workdir: "${{ matrix.compute_env.workdir }}/work/${{ matrix.pipeline.name }}/work-${{ needs.getdate.outputs.date }}"
+                  run_name: "${{ steps.id.outputs.name }}"
+                  profiles: ${{ matrix.pipeline.profiles }}
+                  wait: SUBMITTED
+                  parameters: |
+                    {
+                        "outdir": "${{ matrix.compute_env.workdir }}/${{ matrix.pipeline.name }}/results-test-${{ needs.getdate.outputs.date }}"
+                    }
+        
+              - name: "Store run details as artifact"
+                if: success()
+                run: |
+                  set -euo pipefail
+                  echo ${{ steps.submit-pipeline.outputs.json }} | jq -r '. += { "pipeline": "${{ matrix.pipeline.name }}_${{ matrix.compute_env.name }}" }' \
+                    >> ${{ steps.id.outputs.name }}_${{ steps.id.outputs.workspace }}_${{ needs.getdate.outputs.date }}.json
+        
+              - uses: actions/upload-artifact@v3
+                if: success() || failure()
+                with:
+                  name: ${{ needs.getdate.outputs.date }}_run_details
+                  path: "${{ steps.id.outputs.name }}_${{ steps.id.outputs.workspace }}_${{ needs.getdate.outputs.date }}.json"
+        
+              - uses: actions/upload-artifact@v3
+                if: success() || failure()
+                with:
+                  name: ${{ needs.getdate.outputs.date }}_launch_log
+                  path: tower_action_*.log
+        
+          checkmatrix:
+            runs-on: ubuntu-latest
+            needs: [runtest, getdate]
+            continue-on-error: true
+            outputs:
+              matrix: ${{ steps.matrix.outputs.matrix }}
+            steps:
+              - uses: actions/download-artifact@v3
+                with:
+                  name: ${{ needs.getdate.outputs.date }}_run_details
+                  path: run_details
+        
+              - name: "stage matrix"
+                run: |
+                  set -euo pipefail
+                  echo "matrix=$(cat run_details/* | jq -c --slurp .)" >> $GITHUB_OUTPUT
+                id: matrix
+        
+          checkrun:
+            name: check.${{ matrix.includes.pipeline }}.${{ matrix.includes.workspaceId }}
+            runs-on: ubuntu-latest
+            needs: [getdate, checkmatrix]
+            continue-on-error: true
+            environment: ${{ inputs.timer || 'delay360mins' }}
+            env:
+              TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
+              TOWER_WORKSPACE_ID: ${{ matrix.includes.workspaceId }}
+            strategy:
+              matrix:
+                includes: ${{ fromJSON(needs.checkmatrix.outputs.matrix) }}
+        
+            steps:
+              - name: "print matrix input"
+                run: |
+                  set -euo pipefail
+                  echo "${{ toJSON(matrix) }}"
+        
+              - name: Install tw CLI
+                run: |
+                  set -euo pipefail
+                  wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.8.0/tw-linux-x86_64
+                  mv tw-* tw
+                  chmod +x tw
+                  sudo mv tw /usr/local/bin/
+        
+              - name: Get info
+                if: ${{ !inputs.dryrun }}
+                id: info
+                run: |
+                  set -euo pipefail
+                  tw -o json runs dump -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} --add-task-logs --add-fusion-logs --silent --output ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz
+                  tar -xzvf ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz
+                  tw -o json runs view -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} | jq -r '.general |= . + { "workspace": "${{ matrix.includes.workspaceRef }}", "pipeline": "${{ matrix.includes.pipeline }}", "url": "${{ matrix.includes.workflowUrl }}" }' > workflow-info.json
+                  jq -n 'reduce inputs as $s (.; (.[input_filename|rtrimstr(".json")]) += $s)' *.json > ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}_dump.json
+        
+              - uses: actions/upload-artifact@v3
+                with:
+                  name: ${{ needs.getdate.outputs.date }}_all_run_dumps
+                  path: "${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz"
+        
+              - uses: actions/upload-artifact@v3
+                with:
+                  name: ${{ needs.getdate.outputs.date }}_all_run_json
+                  path: "${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}_dump.json"
+        
+              - name: Clearup
+                if: ${{ (inputs.remove || true) && !inputs.dryrun }}
+                run: |
+                  set -euo pipefail
+                  STATUS=$(tw -o json runs view -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} | jq -r '.general.status')
+                  if [ "SUCCEEDED" = $STATUS ]; then
+                    # Won't delete if run is active
+                    tw -o json runs delete -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }}
+                  else
+                    echo "Run has not finished, delete with 'tw -o json runs delete -w ${{ matrix.includes.workspace }} -i ${{ matrix.includes.workflowId }}' when ready."
+                  fi
+        
+          slack:
+            runs-on: ubuntu-latest
+            needs: [getdate, checkrun]
+            steps:
+              - uses: actions/download-artifact@v3
+                with:
+                  name: ${{ needs.getdate.outputs.date }}_all_run_json
+                  path: runs
+        
+              - name: "Slack"
+                if: ${{ ( github.event_name != 'workflow_dispatch' && inputs.slack ) || true }}
+                run: |
+                  set -euo pipefail
+                  ls -1 runs/*
+                  cat runs/* | jq -r --slurp
+                  export MESSAGE=$(cat runs/* | jq -r --slurp '(["pipeline", "computeEnv", "workspace", "status", "platformVersion", "nextflowVersion", "pipelineRevision", "workflowUrl"] | (., map(length*"-"))), (.[] | [.["workflow-info"]["general"]["pipeline"], .["workflow-info"]["general"]["workspace"], .["workflow-launch"]["computeEnv"]["name"], .["workflow"]["status"], .["service-info"]["version"], .["workflow"]["nextflow"]["version"], .["workflow-launch"]["revision"], .["workflow-info"]["general"]["url"]]) | map(.//"-") | @tsv' | column -ts $'\t')
+                  echo $MESSAGE
+                  curl -X POST -H 'Content-type: application/json' --data "{'text': \"\`\`\`$MESSAGE\`\`\`\"}" ${{ secrets.SLACK_HOOK_URL }}
+        

--- a/.github/workflows/community-showcase.yml
+++ b/.github/workflows/community-showcase.yml
@@ -34,7 +34,7 @@ on:
         required: false
 
   schedule:
-    # Every 2am on Friday and Monday
+    # Every 2am
     - cron: "0 2 * * *"
 
 jobs:

--- a/.github/workflows/community-showcase.yml
+++ b/.github/workflows/community-showcase.yml
@@ -213,6 +213,6 @@ jobs:
           set -euo pipefail
           ls -1 runs/*
           cat runs/* | jq -r --slurp
-          export MESSAGE=$(cat runs/* | jq -r --slurp '(["pipeline", "computeEnv", "workspace", "status", "platformVersion", "nextflowVersion", "pipelineRevision", "workflowUrl"] | (., map(length*"-"))), (.[] | [.["workflow-info"]["general"]["pipeline"], .["workflow-info"]["general"]["workspace"], .["workflow-launch"]["computeEnv"]["name"], .["workflow"]["status"], .["service-info"]["version"], .["workflow"]["nextflow"]["version"], .["workflow-launch"]["revision"], .["workflow-info"]["general"]["url"]]) | map(.//"-") | @tsv' | column -ts $'\t')
+          export MESSAGE=$(cat runs/* | jq -r --slurp '(["pipeline", "workspace", "computeEnv", "status", "platform", "nextflow", "revision", "workflowUrl"] | (., map(length*"-"))), (.[] | [.["workflow-info"]["general"]["pipeline"], .["workflow-info"]["general"]["workspace"], .["workflow-launch"]["computeEnv"]["name"], .["workflow"]["status"], .["service-info"]["version"], .["workflow"]["nextflow"]["version"], .["workflow-launch"]["revision"], .["workflow-info"]["general"]["url"]]) | map(.//"-") | @tsv' | column -ts $'\t')
           echo $MESSAGE
           curl -X POST -H 'Content-type: application/json' --data "{'text': \"\`\`\`$MESSAGE\`\`\`\"}" ${{ secrets.SLACK_HOOK_URL }}

--- a/.github/workflows/community-showcase.yml
+++ b/.github/workflows/community-showcase.yml
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [getdate, checkmatrix]
     continue-on-error: true
-    environment: ${{ inputs.timer || 'delay360mins' }}
+    environment: ${{ inputs.timer || 'delay120mins' }}
     env:
       TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
       TOWER_WORKSPACE_ID: ${{ matrix.includes.workspaceId }}

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -254,6 +254,6 @@ jobs:
           set -euo pipefail
           ls -1 runs/*
           cat runs/* | jq -r --slurp
-          export MESSAGE=$(cat runs/* | jq -r --slurp '(["pipeline", "computeEnv", "workspace", "status", "workflowUrl"] | (., map(length*"-"))), (.[] | [.["workflow-info"]["general"]["pipeline"], .["workflow-info"]["general"]["workspace"], .["workflow-launch"]["computeEnv"]["name"], .["workflow"]["status"], .["workflow-info"]["general"]["url"]]) | @tsv' | column -ts $'\t')
+          export MESSAGE=$(cat runs/* | jq -r --slurp '(["pipeline", "computeEnv", "workspace", "status", "platformVersion", "nextflowVersion", "pipelineRevision", "workflowUrl"] | (., map(length*"-"))), (.[] | [.["workflow-info"]["general"]["pipeline"], .["workflow-info"]["general"]["workspace"], .["workflow-launch"]["computeEnv"]["name"], .["workflow"]["status"], .["service-info"]["version"], .["workflow"]["nextflow"]["version"], .["workflow-launch"]["revision"], .["workflow-info"]["general"]["url"]]) | @tsv' | column -ts $'\t')
           echo $MESSAGE
           curl -X POST -H 'Content-type: application/json' --data "{'text': \"\`\`\`$MESSAGE\`\`\`\"}" ${{ secrets.SLACK_HOOK_URL }}

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -207,11 +207,17 @@ jobs:
         run: |
           set -euo pipefail
           tw -o json runs view -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} | jq -r '.general |= . + { "workspace": "${{ matrix.includes.workspaceRef }}", "pipeline": "${{ matrix.includes.pipeline }}", "url": "${{ matrix.includes.workflowUrl }}" }' > ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.json
+          tw -o json runs dumps -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} --add-task-logs --add-fusion-logs --silent --output ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz
 
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ needs.getdate.outputs.date }}_all_runs
           path: "${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.json"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ needs.getdate.outputs.date }}_all_run_dumps
+          path: "${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz"
 
       - name: Clearup
         if: ${{ (inputs.remove || true) && !inputs.dryrun }}

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -209,7 +209,7 @@ jobs:
           tw -o json runs dump -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} --add-task-logs --add-fusion-logs --silent --output ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz
           tar -xzvf ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz
           tw -o json runs view -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} | jq -r '.general |= . + { "workspace": "${{ matrix.includes.workspaceRef }}", "pipeline": "${{ matrix.includes.pipeline }}", "url": "${{ matrix.includes.workflowUrl }}" }' > workflow-info.json
-          jq -n 'reduce inputs as $s (.; .[input_filename] += $s)' *.json > ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}_dump.json
+          jq -n 'reduce inputs as $s (.; (.[input_filename|rtrimstr(".json")]) += $s)' *.json > ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}_dump.json
           cp workflow-info.json ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.json
 
       - uses: actions/upload-artifact@v3
@@ -245,7 +245,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: ${{ needs.getdate.outputs.date }}_all_runs
+          name: ${{ needs.getdate.outputs.date }}_all_run_dumps_json
           path: runs
 
       - name: "Slack"
@@ -254,6 +254,6 @@ jobs:
           set -euo pipefail
           ls -1 runs/*
           cat runs/* | jq -r --slurp
-          export MESSAGE=$(cat runs/* | jq -r --slurp '(["pipeline", "computeEnv", "workspace", "status", "workflowUrl"] | (., map(length*"-"))), (.[] | [.general.pipeline, .general.computeEnv, .general.workspace, .general.status, .general.url]) | @tsv' | column -ts $'\t')
+          export MESSAGE=$(cat runs/* | jq -r --slurp '(["pipeline", "computeEnv", "workspace", "status", "workflowUrl"] | (., map(length*"-"))), (.[] | [.["workflow-info"]["general"]["pipeline"], .["workflow-info"]["general"]["workspace"], .["workflow-launch"]["computeEnv"]["name"], .["workflow"]["status"], .["workflow-info"]["general]["url"]]) | @tsv' | column -ts $'\t')
           echo $MESSAGE
           curl -X POST -H 'Content-type: application/json' --data "{'text': \"\`\`\`$MESSAGE\`\`\`\"}" ${{ secrets.SLACK_HOOK_URL }}

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -58,25 +58,25 @@ jobs:
       matrix:
         pipeline:
           - { name: hello, url: hello, latest: true, profiles: "" }
-          - {
-              name: rnaseq,
-              url: nf-core-rnaseq,
-              latest: true,
-              profiles: "test",
-            }
-          - {
-              name: viralrecon-illumina,
-              url: nf-core-viralrecon-illumina,
-              latest: true,
-              profiles: "test",
-            }
-          - {
-              name: viralrecon-nanopore,
-              url: nf-core-viralrecon-nanopore,
-              latest: true,
-              profiles: "test_nanopore",
-            }
-          - { name: sarek, url: nf-core-sarek, latest: true, profiles: "test" }
+          # - {
+          #     name: rnaseq,
+          #     url: nf-core-rnaseq,
+          #     latest: true,
+          #     profiles: "test",
+          #   }
+          # - {
+          #     name: viralrecon-illumina,
+          #     url: nf-core-viralrecon-illumina,
+          #     latest: true,
+          #     profiles: "test",
+          #   }
+          # - {
+          #     name: viralrecon-nanopore,
+          #     url: nf-core-viralrecon-nanopore,
+          #     latest: true,
+          #     profiles: "test_nanopore",
+          #   }
+          # - { name: sarek, url: nf-core-sarek, latest: true, profiles: "test" }
         compute_env:
           - {
               name: aws,
@@ -84,33 +84,33 @@ jobs:
               workdir: "s3://seqeralabs-showcase",
               workspace_id: "138659136604200",
             }
-          - {
-              name: azure,
-              ref: seqera_azure_virginia_fusion,
-              workdir: "az://seqeralabs-showcase",
-              workspace_id: "138659136604200",
-            }
-          - {
-              name: gcp,
-              ref: seqera_gcp_finland_fusion,
-              workdir: "gs://seqeralabs-showcase-eu-north-1",
-              workspace_id: "138659136604200",
-            }
-        include:
-          - compute_env:
-              {
-                name: aws,
-                ref: seqera_aws_ireland_fusionv2_nvme,
-                workdir: "s3://seqeralabs-showcase",
-                workspace_id: "138659136604200",
-              }
-            pipeline:
-              {
-                name: sentieon,
-                url: nf-sentieon,
-                latest: true,
-                profiles: "test",
-              }
+        #   - {
+        #       name: azure,
+        #       ref: seqera_azure_virginia_fusion,
+        #       workdir: "az://seqeralabs-showcase",
+        #       workspace_id: "138659136604200",
+        #     }
+        #   - {
+        #       name: gcp,
+        #       ref: seqera_gcp_finland_fusion,
+        #       workdir: "gs://seqeralabs-showcase-eu-north-1",
+        #       workspace_id: "138659136604200",
+        #     }
+        # include:
+        #   - compute_env:
+        #       {
+        #         name: aws,
+        #         ref: seqera_aws_ireland_fusionv2_nvme,
+        #         workdir: "s3://seqeralabs-showcase",
+        #         workspace_id: "138659136604200",
+        #       }
+        #     pipeline:
+        #       {
+        #         name: sentieon,
+        #         url: nf-sentieon,
+        #         latest: true,
+        #         profiles: "test",
+        #       }
 
     steps:
       - name: "export unique run name"

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -196,7 +196,7 @@ jobs:
       - name: Install tw CLI
         run: |
           set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.9.0/tw-linux-x86_64
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.8.0/tw-linux-x86_64
           mv tw-* tw
           chmod +x tw
           sudo mv tw /usr/local/bin/

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -84,18 +84,18 @@ jobs:
               workdir: "s3://seqeralabs-showcase",
               workspace_id: "138659136604200",
             }
-        #   - {
-        #       name: azure,
-        #       ref: seqera_azure_virginia_fusion,
-        #       workdir: "az://seqeralabs-showcase",
-        #       workspace_id: "138659136604200",
-        #     }
-        #   - {
-        #       name: gcp,
-        #       ref: seqera_gcp_finland_fusion,
-        #       workdir: "gs://seqeralabs-showcase-eu-north-1",
-        #       workspace_id: "138659136604200",
-        #     }
+          - {
+              name: azure,
+              ref: seqera_azure_virginia_fusion,
+              workdir: "az://seqeralabs-showcase",
+              workspace_id: "138659136604200",
+            }
+          - {
+              name: gcp,
+              ref: seqera_gcp_finland_fusion,
+              workdir: "gs://seqeralabs-showcase-eu-north-1",
+              workspace_id: "138659136604200",
+            }
         # include:
         #   - compute_env:
         #       {

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -34,7 +34,7 @@ on:
         required: false
 
   schedule:
-    # Every 2am on Friday and Monday
+    # Every 2am
     - cron: "0 2 * * *"
 
 jobs:

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -58,25 +58,25 @@ jobs:
       matrix:
         pipeline:
           - { name: hello, url: hello, latest: true, profiles: "" }
-          # - {
-          #     name: rnaseq,
-          #     url: nf-core-rnaseq,
-          #     latest: true,
-          #     profiles: "test",
-          #   }
-          # - {
-          #     name: viralrecon-illumina,
-          #     url: nf-core-viralrecon-illumina,
-          #     latest: true,
-          #     profiles: "test",
-          #   }
-          # - {
-          #     name: viralrecon-nanopore,
-          #     url: nf-core-viralrecon-nanopore,
-          #     latest: true,
-          #     profiles: "test_nanopore",
-          #   }
-          # - { name: sarek, url: nf-core-sarek, latest: true, profiles: "test" }
+          - {
+              name: rnaseq,
+              url: nf-core-rnaseq,
+              latest: true,
+              profiles: "test",
+            }
+          - {
+              name: viralrecon-illumina,
+              url: nf-core-viralrecon-illumina,
+              latest: true,
+              profiles: "test",
+            }
+          - {
+              name: viralrecon-nanopore,
+              url: nf-core-viralrecon-nanopore,
+              latest: true,
+              profiles: "test_nanopore",
+            }
+          - { name: sarek, url: nf-core-sarek, latest: true, profiles: "test" }
         compute_env:
           - {
               name: aws,
@@ -84,33 +84,33 @@ jobs:
               workdir: "s3://seqeralabs-showcase",
               workspace_id: "138659136604200",
             }
-          # - {
-          #     name: azure,
-          #     ref: seqera_azure_virginia_fusion,
-          #     workdir: "az://seqeralabs-showcase",
-          #     workspace_id: "138659136604200",
-          #   }
-          # - {
-          #     name: gcp,
-          #     ref: seqera_gcp_finland_fusion,
-          #     workdir: "gs://seqeralabs-showcase-eu-north-1",
-          #     workspace_id: "138659136604200",
-          #   }
-        # include:
-        #   - compute_env:
-        #       {
-        #         name: aws,
-        #         ref: seqera_aws_ireland_fusionv2_nvme,
-        #         workdir: "s3://seqeralabs-showcase",
-        #         workspace_id: "138659136604200",
-        #       }
-        #     pipeline:
-        #       {
-        #         name: sentieon,
-        #         url: nf-sentieon,
-        #         latest: true,
-        #         profiles: "test",
-        #       }
+          - {
+              name: azure,
+              ref: seqera_azure_virginia_fusion,
+              workdir: "az://seqeralabs-showcase",
+              workspace_id: "138659136604200",
+            }
+          - {
+              name: gcp,
+              ref: seqera_gcp_finland_fusion,
+              workdir: "gs://seqeralabs-showcase-eu-north-1",
+              workspace_id: "138659136604200",
+            }
+        include:
+          - compute_env:
+              {
+                name: aws,
+                ref: seqera_aws_ireland_fusionv2_nvme,
+                workdir: "s3://seqeralabs-showcase",
+                workspace_id: "138659136604200",
+              }
+            pipeline:
+              {
+                name: sentieon,
+                url: nf-sentieon,
+                latest: true,
+                profiles: "test",
+              }
 
     steps:
       - name: "export unique run name"

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -58,25 +58,25 @@ jobs:
       matrix:
         pipeline:
           - { name: hello, url: hello, latest: true, profiles: "" }
-          - {
-              name: rnaseq,
-              url: nf-core-rnaseq,
-              latest: true,
-              profiles: "test",
-            }
-          - {
-              name: viralrecon-illumina,
-              url: nf-core-viralrecon-illumina,
-              latest: true,
-              profiles: "test",
-            }
-          - {
-              name: viralrecon-nanopore,
-              url: nf-core-viralrecon-nanopore,
-              latest: true,
-              profiles: "test_nanopore",
-            }
-          - { name: sarek, url: nf-core-sarek, latest: true, profiles: "test" }
+          # - {
+          #     name: rnaseq,
+          #     url: nf-core-rnaseq,
+          #     latest: true,
+          #     profiles: "test",
+          #   }
+          # - {
+          #     name: viralrecon-illumina,
+          #     url: nf-core-viralrecon-illumina,
+          #     latest: true,
+          #     profiles: "test",
+          #   }
+          # - {
+          #     name: viralrecon-nanopore,
+          #     url: nf-core-viralrecon-nanopore,
+          #     latest: true,
+          #     profiles: "test_nanopore",
+          #   }
+          # - { name: sarek, url: nf-core-sarek, latest: true, profiles: "test" }
         compute_env:
           - {
               name: aws,
@@ -84,33 +84,33 @@ jobs:
               workdir: "s3://seqeralabs-showcase",
               workspace_id: "138659136604200",
             }
-          - {
-              name: azure,
-              ref: seqera_azure_virginia_fusion,
-              workdir: "az://seqeralabs-showcase",
-              workspace_id: "138659136604200",
-            }
-          - {
-              name: gcp,
-              ref: seqera_gcp_finland_fusion,
-              workdir: "gs://seqeralabs-showcase-eu-north-1",
-              workspace_id: "138659136604200",
-            }
-        include:
-          - compute_env:
-              {
-                name: aws,
-                ref: seqera_aws_ireland_fusionv2_nvme,
-                workdir: "s3://seqeralabs-showcase",
-                workspace_id: "138659136604200",
-              }
-            pipeline:
-              {
-                name: sentieon,
-                url: nf-sentieon,
-                latest: true,
-                profiles: "test",
-              }
+          # - {
+          #     name: azure,
+          #     ref: seqera_azure_virginia_fusion,
+          #     workdir: "az://seqeralabs-showcase",
+          #     workspace_id: "138659136604200",
+          #   }
+          # - {
+          #     name: gcp,
+          #     ref: seqera_gcp_finland_fusion,
+          #     workdir: "gs://seqeralabs-showcase-eu-north-1",
+          #     workspace_id: "138659136604200",
+          #   }
+        # include:
+        #   - compute_env:
+        #       {
+        #         name: aws,
+        #         ref: seqera_aws_ireland_fusionv2_nvme,
+        #         workdir: "s3://seqeralabs-showcase",
+        #         workspace_id: "138659136604200",
+        #       }
+        #     pipeline:
+        #       {
+        #         name: sentieon,
+        #         url: nf-sentieon,
+        #         latest: true,
+        #         profiles: "test",
+        #       }
 
     steps:
       - name: "export unique run name"

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -248,6 +248,6 @@ jobs:
           set -euo pipefail
           ls -1 runs/*
           cat runs/* | jq -r --slurp
-          export MESSAGE=$(cat runs/* | jq -r --slurp '(["pipeline", "computeEnv", "workspace", "status", "platformVersion", "nextflowVersion", "pipelineRevision", "workflowUrl"] | (., map(length*"-"))), (.[] | [.["workflow-info"]["general"]["pipeline"], .["workflow-info"]["general"]["workspace"], .["workflow-launch"]["computeEnv"]["name"], .["workflow"]["status"], .["service-info"]["version"], .["workflow"]["nextflow"]["version"], .["workflow-launch"]["revision"], .["workflow-info"]["general"]["url"]]) | map(.//"-") | @tsv' | column -ts $'\t')
+          export MESSAGE=$(cat runs/* | jq -r --slurp '(["pipeline", "workspace", "computeEnv", "status", "platform", "nextflow", "revision", "workflowUrl"] | (., map(length*"-"))), (.[] | [.["workflow-info"]["general"]["pipeline"], .["workflow-info"]["general"]["workspace"], .["workflow-launch"]["computeEnv"]["name"], .["workflow"]["status"], .["service-info"]["version"], .["workflow"]["nextflow"]["version"], .["workflow-launch"]["revision"], .["workflow-info"]["general"]["url"]]) | map(.//"-") | @tsv' | column -ts $'\t')
           echo $MESSAGE
           curl -X POST -H 'Content-type: application/json' --data "{'text': \"\`\`\`$MESSAGE\`\`\`\"}" ${{ secrets.SLACK_HOOK_URL }}

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -254,6 +254,6 @@ jobs:
           set -euo pipefail
           ls -1 runs/*
           cat runs/* | jq -r --slurp
-          export MESSAGE=$(cat runs/* | jq -r --slurp '(["pipeline", "computeEnv", "workspace", "status", "workflowUrl"] | (., map(length*"-"))), (.[] | [.["workflow-info"]["general"]["pipeline"], .["workflow-info"]["general"]["workspace"], .["workflow-launch"]["computeEnv"]["name"], .["workflow"]["status"], .["workflow-info"]["general]["url"]]) | @tsv' | column -ts $'\t')
+          export MESSAGE=$(cat runs/* | jq -r --slurp '(["pipeline", "computeEnv", "workspace", "status", "workflowUrl"] | (., map(length*"-"))), (.[] | [.["workflow-info"]["general"]["pipeline"], .["workflow-info"]["general"]["workspace"], .["workflow-launch"]["computeEnv"]["name"], .["workflow"]["status"], .["workflow-info"]["general"]["url"]]) | @tsv' | column -ts $'\t')
           echo $MESSAGE
           curl -X POST -H 'Content-type: application/json' --data "{'text': \"\`\`\`$MESSAGE\`\`\`\"}" ${{ secrets.SLACK_HOOK_URL }}

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -248,6 +248,6 @@ jobs:
           set -euo pipefail
           ls -1 runs/*
           cat runs/* | jq -r --slurp
-          export MESSAGE=$(cat runs/* | jq -r --slurp '(["pipeline", "computeEnv", "workspace", "status", "platformVersion", "nextflowVersion", "pipelineRevision", "workflowUrl"] | (., map(length*"-"))), (.[] | [.["workflow-info"]["general"]["pipeline"] // "-", .["workflow-info"]["general"]["workspace"] // "-", .["workflow-launch"]["computeEnv"]["name"] // "-", .["workflow"]["status"] // "-", .["service-info"]["version"] // "-", .["workflow"]["nextflow"]["version"] // "-", .["workflow-launch"]["revision"] // "-", .["workflow-info"]["general"]["url"]] // "-") | @tsv' | column -ts $'\t')
+          export MESSAGE=$(cat runs/* | jq -r --slurp '(["pipeline", "computeEnv", "workspace", "status", "platformVersion", "nextflowVersion", "pipelineRevision", "workflowUrl"] | (., map(length*"-"))), (.[] | [.["workflow-info"]["general"]["pipeline"], .["workflow-info"]["general"]["workspace"], .["workflow-launch"]["computeEnv"]["name"], .["workflow"]["status"], .["service-info"]["version"], .["workflow"]["nextflow"]["version"], .["workflow-launch"]["revision"], .["workflow-info"]["general"]["url"]]) | map(.//"-") | @tsv' | column -ts $'\t')
           echo $MESSAGE
           curl -X POST -H 'Content-type: application/json' --data "{'text': \"\`\`\`$MESSAGE\`\`\`\"}" ${{ secrets.SLACK_HOOK_URL }}

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [getdate, checkmatrix]
     continue-on-error: true
-    environment: ${{ inputs.timer || 'delay360mins' }}
+    environment: ${{ inputs.timer || 'delay120mins' }}
     env:
       TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
       TOWER_WORKSPACE_ID: ${{ matrix.includes.workspaceId }}

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -57,13 +57,13 @@ jobs:
     strategy:
       matrix:
         pipeline:
-          - { name: hello, url: hello, latest: true, profiles: "" }
-          # - {
-          #     name: rnaseq,
-          #     url: nf-core-rnaseq,
-          #     latest: true,
-          #     profiles: "test",
-          #   }
+          # - { name: hello, url: hello, latest: true, profiles: "" }
+          - {
+              name: rnaseq,
+              url: nf-core-rnaseq,
+              latest: true,
+              profiles: "test",
+            }
           # - {
           #     name: viralrecon-illumina,
           #     url: nf-core-viralrecon-illumina,

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -207,7 +207,7 @@ jobs:
         run: |
           set -euo pipefail
           tw -o json runs view -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} | jq -r '.general |= . + { "workspace": "${{ matrix.includes.workspaceRef }}", "pipeline": "${{ matrix.includes.pipeline }}", "url": "${{ matrix.includes.workflowUrl }}" }' > ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.json
-          tw -o json runs dumps -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} --add-task-logs --add-fusion-logs --silent --output ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz
+          tw -o json runs dump -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} --add-task-logs --add-fusion-logs --silent --output ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -112,7 +112,6 @@ jobs:
                 profiles: "test",
               }
 
-
     steps:
       - name: "export unique run name"
         run: |
@@ -154,7 +153,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: success() || failure()
         with:
-          name: ${{ matrix.pipeline.name }}_${{ matrix.compute_env.name }}_log
+          name: ${{ needs.getdate.outputs.date }}_launch_log
           path: tower_action_*.log
 
   checkmatrix:

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -196,7 +196,7 @@ jobs:
       - name: Install tw CLI
         run: |
           set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.7.3/tw-0.7.3-linux-x86_64
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.9.0/tw-linux-x86_64
           mv tw-* tw
           chmod +x tw
           sudo mv tw /usr/local/bin/

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -248,6 +248,6 @@ jobs:
           set -euo pipefail
           ls -1 runs/*
           cat runs/* | jq -r --slurp
-          export MESSAGE=$(cat runs/* | jq -r --slurp '(["pipeline", "computeEnv", "workspace", "status", "platformVersion", "nextflowVersion", "pipelineRevision", "workflowUrl"] | (., map(length*"-"))), (.[] | [.["workflow-info"]["general"]["pipeline"], .["workflow-info"]["general"]["workspace"], .["workflow-launch"]["computeEnv"]["name"], .["workflow"]["status"], .["service-info"]["version"], .["workflow"]["nextflow"]["version"], .["workflow-launch"]["revision"], .["workflow-info"]["general"]["url"]]) | @tsv' | column -ts $'\t')
+          export MESSAGE=$(cat runs/* | jq -r --slurp '(["pipeline", "computeEnv", "workspace", "status", "platformVersion", "nextflowVersion", "pipelineRevision", "workflowUrl"] | (., map(length*"-"))), (.[] | [.["workflow-info"]["general"]["pipeline"] // "-", .["workflow-info"]["general"]["workspace"] // "-", .["workflow-launch"]["computeEnv"]["name"] // "-", .["workflow"]["status"] // "-", .["service-info"]["version"] // "-", .["workflow"]["nextflow"]["version"] // "-", .["workflow-launch"]["revision"] // "-", .["workflow-info"]["general"]["url"]] // "-") | @tsv' | column -ts $'\t')
           echo $MESSAGE
           curl -X POST -H 'Content-type: application/json' --data "{'text': \"\`\`\`$MESSAGE\`\`\`\"}" ${{ secrets.SLACK_HOOK_URL }}

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -210,12 +210,6 @@ jobs:
           tar -xzvf ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz
           tw -o json runs view -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} | jq -r '.general |= . + { "workspace": "${{ matrix.includes.workspaceRef }}", "pipeline": "${{ matrix.includes.pipeline }}", "url": "${{ matrix.includes.workflowUrl }}" }' > workflow-info.json
           jq -n 'reduce inputs as $s (.; (.[input_filename|rtrimstr(".json")]) += $s)' *.json > ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}_dump.json
-          cp workflow-info.json ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.json
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ needs.getdate.outputs.date }}_all_runs
-          path: "${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.json"
 
       - uses: actions/upload-artifact@v3
         with:
@@ -224,7 +218,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: ${{ needs.getdate.outputs.date }}_all_run_dumps_json
+          name: ${{ needs.getdate.outputs.date }}_all_run_json
           path: "${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}_dump.json"
 
       - name: Clearup
@@ -245,7 +239,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: ${{ needs.getdate.outputs.date }}_all_run_dumps_json
+          name: ${{ needs.getdate.outputs.date }}_all_run_json
           path: runs
 
       - name: "Slack"

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -57,26 +57,26 @@ jobs:
     strategy:
       matrix:
         pipeline:
-          # - { name: hello, url: hello, latest: true, profiles: "" }
+          - { name: hello, url: hello, latest: true, profiles: "" }
           - {
               name: rnaseq,
               url: nf-core-rnaseq,
               latest: true,
               profiles: "test",
             }
-          # - {
-          #     name: viralrecon-illumina,
-          #     url: nf-core-viralrecon-illumina,
-          #     latest: true,
-          #     profiles: "test",
-          #   }
-          # - {
-          #     name: viralrecon-nanopore,
-          #     url: nf-core-viralrecon-nanopore,
-          #     latest: true,
-          #     profiles: "test_nanopore",
-          #   }
-          # - { name: sarek, url: nf-core-sarek, latest: true, profiles: "test" }
+          - {
+              name: viralrecon-illumina,
+              url: nf-core-viralrecon-illumina,
+              latest: true,
+              profiles: "test",
+            }
+          - {
+              name: viralrecon-nanopore,
+              url: nf-core-viralrecon-nanopore,
+              latest: true,
+              profiles: "test_nanopore",
+            }
+          - { name: sarek, url: nf-core-sarek, latest: true, profiles: "test" }
         compute_env:
           - {
               name: aws,
@@ -96,21 +96,21 @@ jobs:
               workdir: "gs://seqeralabs-showcase-eu-north-1",
               workspace_id: "138659136604200",
             }
-        # include:
-        #   - compute_env:
-        #       {
-        #         name: aws,
-        #         ref: seqera_aws_ireland_fusionv2_nvme,
-        #         workdir: "s3://seqeralabs-showcase",
-        #         workspace_id: "138659136604200",
-        #       }
-        #     pipeline:
-        #       {
-        #         name: sentieon,
-        #         url: nf-sentieon,
-        #         latest: true,
-        #         profiles: "test",
-        #       }
+        include:
+          - compute_env:
+              {
+                name: aws,
+                ref: seqera_aws_ireland_fusionv2_nvme,
+                workdir: "s3://seqeralabs-showcase",
+                workspace_id: "138659136604200",
+              }
+            pipeline:
+              {
+                name: sentieon,
+                url: nf-sentieon,
+                latest: true,
+                profiles: "test",
+              }
 
     steps:
       - name: "export unique run name"

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -206,8 +206,11 @@ jobs:
         id: info
         run: |
           set -euo pipefail
-          tw -o json runs view -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} | jq -r '.general |= . + { "workspace": "${{ matrix.includes.workspaceRef }}", "pipeline": "${{ matrix.includes.pipeline }}", "url": "${{ matrix.includes.workflowUrl }}" }' > ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.json
           tw -o json runs dump -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} --add-task-logs --add-fusion-logs --silent --output ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz
+          tar -xzvf ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz
+          tw -o json runs view -w ${{ matrix.includes.workspaceId }} -i ${{ matrix.includes.workflowId }} | jq -r '.general |= . + { "workspace": "${{ matrix.includes.workspaceRef }}", "pipeline": "${{ matrix.includes.pipeline }}", "url": "${{ matrix.includes.workflowUrl }}" }' > workflow-info.json
+          jq -n 'reduce inputs as $s (.; .[input_filename] += $s)' *.json > ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}_dump.json
+          cp workflow-info.json ${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.json
 
       - uses: actions/upload-artifact@v3
         with:
@@ -218,6 +221,11 @@ jobs:
         with:
           name: ${{ needs.getdate.outputs.date }}_all_run_dumps
           path: "${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}.tar.gz"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ needs.getdate.outputs.date }}_all_run_dumps_json
+          path: "${{ matrix.includes.pipeline }}_${{ matrix.includes.workspaceId }}_${{ needs.getdate.outputs.date }}_dump.json"
 
       - name: Clearup
         if: ${{ (inputs.remove || true) && !inputs.dryrun }}


### PR DESCRIPTION
Changes: 
 - Updates `tw` to version v0.8.0 which includes `tw runs dump`
 - Uses `tw runs dump` to collect more pipeline run metrics
 - Gathers output of `tw runs dump` into single JSON which is used to create Slack hook
 - Adds additional `tw runs info` information to dump JSON
 - Creates new output table based on `tw runs dump` information which adds the following:
     - platform (version)
     - nextflow (version)
     - revision (pipeline version)

Together this should help us identify the cause of problems faster.
     
```
pipeline   workspace                computeEnv                        status   platform        nextflow  revision  workflowUrl
--------   ---------                ----------                        ------   --------        --------  --------  -----------
hello_aws  [seqeralabs / showcase]  seqera_aws_ireland_fusionv2_nvme  RUNNING  23.3.0-cycle23  23.10.0   master    https://tower.nf/orgs/seqeralabs/workspaces/showcase/watch/3HKVd1Wl1UtBaC
```