### PR TITLE
Change platform endpoint URL to api.cloud.seqera.io to correct output URL

### DIFF
--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -49,6 +49,9 @@ on:
     # Every 2am
     - cron: "0 2 * * *"
 
+env:
+  TOWER_API_ENDPOINT: "https://api.cloud.seqera.io"
+
 # This workflow launches pipelines in Tower, waits for completion,
 # extracts metadata, and optionally sends Slack notifications.
 


### PR DESCRIPTION
This will correct the output URL from https://tower.nf/ to https://cloud.seqera.io/ after launching the pipeline.