### PR TITLE
Support custom pre-run and config scripts

### DIFF
--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -106,8 +106,8 @@ jobs:
           python launch_pipelines.py \
             -l DEBUG \
             -i \
-            pipelines/*.yaml \
-            compute-envs/*.yaml \
+            pipelines/hello.yaml \
+            compute-envs/aws.yaml \
             include/*.yaml \
             exclude/* \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.pre_run ) && format('--pre_run {0}', inputs.pre_run) || '' }} \

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -106,8 +106,8 @@ jobs:
           python launch_pipelines.py \
             -l DEBUG \
             -i \
-            pipelines/hello.yaml \
-            compute-envs/aws.yaml \
+            pipelines/*.yaml \
+            compute-envs/*.yaml \
             include/*.yaml \
             exclude/* \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.pre_run ) && format('--pre_run "{0}"', inputs.pre_run) || '' }} \

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -110,8 +110,8 @@ jobs:
             compute-envs/aws.yaml \
             include/*.yaml \
             exclude/* \
-            ${{ ( github.event_name != 'workflow_dispatch' || inputs.pre_run ) && format('--pre_run {0}', inputs.pre_run) || '' }} \
-            ${{ ( github.event_name != 'workflow_dispatch' || inputs.config ) && format('--config {0}', inputs.config) || '' }} \
+            ${{ ( github.event_name != 'workflow_dispatch' || inputs.pre_run ) && format('--pre_run "{0}"', inputs.pre_run) || '' }} \
+            ${{ ( github.event_name != 'workflow_dispatch' || inputs.config ) && format('--config "{0}"', inputs.config) || '' }} \
             ${{ ( github.event_name == 'workflow_dispatch' && inputs.dryrun ) && '--dryrun' || '' }} \
             -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -46,10 +46,12 @@ on:
         required: false
       pre_run:
         description: Pre-run command
+        default: ""
         type: string
         required: false
       config:
         description: Nextflow config to add
+        default: ""
         type: string
         required: false
 
@@ -108,8 +110,8 @@ jobs:
             compute-envs/*.yaml \
             include/*.yaml \
             exclude/* \
-            ${{ ( github.event_name != 'workflow_dispatch' || inputs.pre_run ) && '--pre_run ${{ inputs.pre_run }}' || '' }} \
-            ${{ ( github.event_name != 'workflow_dispatch' || inputs.config ) && '--config ${{ inputs.config }}' || '' }} \
+            ${{ ( github.event_name != 'workflow_dispatch' && inputs.pre_run ) && '--pre_run ${{ inputs.pre_run }}' || '' }} \
+            ${{ ( github.event_name != 'workflow_dispatch' && inputs.config ) && '--config ${{ inputs.config }}' || '' }} \
             ${{ ( github.event_name == 'workflow_dispatch' && inputs.dryrun ) && '--dryrun' || '' }} \
             -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -44,6 +44,14 @@ on:
         default: false
         type: boolean
         required: false
+      pre_run:
+        description: Pre-run command
+        type: string
+        required: false
+      config:
+        description: Nextflow config to add
+        type: string
+        required: false
 
   schedule:
     # Every 2am
@@ -100,6 +108,8 @@ jobs:
             compute-envs/*.yaml \
             include/*.yaml \
             exclude/* \
+            ${{ ( github.event_name != 'workflow_dispatch' || inputs.pre_run ) && '--pre_run ${{ inputs.pre_run }}' || '' }} \
+            ${{ ( github.event_name != 'workflow_dispatch' || inputs.config ) && '--config ${{ inputs.config }}' || '' }} \
             ${{ ( github.event_name == 'workflow_dispatch' && inputs.dryrun ) && '--dryrun' || '' }} \
             -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 

--- a/.github/workflows/seqera-showcase.yml
+++ b/.github/workflows/seqera-showcase.yml
@@ -110,8 +110,8 @@ jobs:
             compute-envs/*.yaml \
             include/*.yaml \
             exclude/* \
-            ${{ ( github.event_name != 'workflow_dispatch' && inputs.pre_run ) && '--pre_run ${{ inputs.pre_run }}' || '' }} \
-            ${{ ( github.event_name != 'workflow_dispatch' && inputs.config ) && '--config ${{ inputs.config }}' || '' }} \
+            ${{ ( github.event_name != 'workflow_dispatch' || inputs.pre_run ) && format('--pre_run {0}', inputs.pre_run) || '' }} \
+            ${{ ( github.event_name != 'workflow_dispatch' || inputs.config ) && format('--config {0}', inputs.config) || '' }} \
             ${{ ( github.event_name == 'workflow_dispatch' && inputs.dryrun ) && '--dryrun' || '' }} \
             -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 


### PR DESCRIPTION
This PR adds the ability to customise the pre-run script or nextflow.config at runtime. Currently, it does this via a string input so you have to specify `--pre_run 'export NXF_VER=23.10.1'`, this limits its usefulness for large scripts and config files but means it can easily be used with the Github Action runner.

Changes:
 - Can add pre-run and configs via YAML or via CLI
 - CLI takes precedence over YAML
 - Implemented in Github Action
 - Use string as input and populate a text file - fairly limited in scope

Key questions:
- this solves the immediate use case of setting the Nextflow version. 
- Are we likely to use larger pre-run scripts and configs in this workflow? 
- Do we want to support files instead.

After this change, Github Action will look like this:
![image](https://github.com/seqeralabs/showcase-automation/assets/12817534/9bb09272-6a62-4be7-ab96-41f6f4719d0f)
