### PR TITLE
Labels can be added during manual launch

### DIFF
--- a/.github/workflows/seqera-showcase-enterprise.yml
+++ b/.github/workflows/seqera-showcase-enterprise.yml
@@ -125,7 +125,7 @@ jobs:
             ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '' }} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '--labels "automation"' }} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.dryrun == 'true') && '--dryrun' || '' }} \
             -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 

--- a/.github/workflows/seqera-showcase-enterprise.yml
+++ b/.github/workflows/seqera-showcase-enterprise.yml
@@ -60,6 +60,11 @@ on:
         default: ""
         type: string
         required: false
+      labels:
+        description: Labels to add to the pipeline
+        default: ""
+        type: string
+        required: false
 
   schedule:
     # Every 2am
@@ -120,6 +125,7 @@ jobs:
             ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '' }} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.dryrun == 'true') && '--dryrun' || '' }} \
             -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 

--- a/.github/workflows/seqera-showcase-production.yml
+++ b/.github/workflows/seqera-showcase-production.yml
@@ -125,7 +125,7 @@ jobs:
             ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '' }} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '--labels "automation"' }} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.dryrun == 'true') && '--dryrun' || '' }} \
             -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 

--- a/.github/workflows/seqera-showcase-production.yml
+++ b/.github/workflows/seqera-showcase-production.yml
@@ -60,6 +60,11 @@ on:
         default: ""
         type: string
         required: false
+      labels:
+        description: Labels to add to the pipeline
+        default: ""
+        type: string
+        required: false
 
   schedule:
     # Every 2am
@@ -120,6 +125,7 @@ jobs:
             ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '' }} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.dryrun == 'true') && '--dryrun' || '' }} \
             -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 

--- a/.github/workflows/seqera-showcase-staging.yml
+++ b/.github/workflows/seqera-showcase-staging.yml
@@ -60,6 +60,11 @@ on:
         default: ""
         type: string
         required: false
+      labels:
+        description: Labels to add to the pipeline
+        default: ""
+        type: string
+        required: false
 
   # schedule:
   #   # Every 2am
@@ -117,6 +122,7 @@ jobs:
             ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '' }} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.dryrun == 'true') && '--dryrun' || '' }} \
             -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 

--- a/.github/workflows/seqera-showcase-staging.yml
+++ b/.github/workflows/seqera-showcase-staging.yml
@@ -122,7 +122,7 @@ jobs:
             ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '' }} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '--labels "automation"' }} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.dryrun == 'true') && '--dryrun' || '' }} \
             -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 


### PR DESCRIPTION
This PR adds labels that can be added during manual launch (workflow_dispatch).

All labels are applied to every pipeline run in the same manner, no granularity per label.

Fixes #38
