### PR TITLE
Showcase aws move

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Example:
 compute-envs:
   - ref: aws
     name: seqera_aws_ireland_fusionv2_nvme
-    workdir: s3://seqeralabs-showcase
+    workdir: s3://seqera-showcase
     workspace: '138659136604200'
 ```
 
@@ -86,7 +86,7 @@ include:
     compute_environment:
       ref: aws
       name: seqera_aws_ireland_fusionv2_nvme
-      workdir: s3://seqeralabs-showcase
+      workdir: s3://seqera-showcase
       workspace: '138659136604200'
 ```
 

--- a/compute-envs/production-aws.yaml
+++ b/compute-envs/production-aws.yaml
@@ -1,5 +1,5 @@
 compute-envs:
   - ref: aws
     name: seqera_aws_ireland_fusion_nvme
-    workdir: s3://seqeralabs-showcase
+    workdir: s3://seqera-showcase
     workspace: "138659136604200"

--- a/compute-envs/production-aws.yaml
+++ b/compute-envs/production-aws.yaml
@@ -1,5 +1,5 @@
 compute-envs:
   - ref: aws
     name: seqera_aws_ireland_fusion_nvme
-    workdir: s3://seqera-showcase
+    workdir: s3://seqera-showcase/scratch/cicd
     workspace: "138659136604200"

--- a/compute-envs/staging-aws.yaml
+++ b/compute-envs/staging-aws.yaml
@@ -2,5 +2,5 @@
 compute-envs:
   - ref: aws
     name: seqera_aws_ireland_fusion_nvme
-    workdir: s3://seqera-showcase
+    workdir: s3://seqera-showcase/scratch/cicd
     workspace: "14715071736572"

--- a/compute-envs/staging-aws.yaml
+++ b/compute-envs/staging-aws.yaml
@@ -2,5 +2,5 @@
 compute-envs:
   - ref: aws
     name: seqera_aws_ireland_fusion_nvme
-    workdir: s3://seqeralabs-showcase
+    workdir: s3://seqera-showcase
     workspace: "14715071736572"

--- a/exclude/exclude.yaml
+++ b/exclude/exclude.yaml
@@ -8,5 +8,5 @@ exclude:
     compute_environment:
       ref: aws
       name: seqera_aws_ireland_fusionv2_nvme
-      workdir: s3://seqera-showcase
+      workdir: s3://seqera-showcase/scratch/cicd
       workspace: "138659136604200"

--- a/exclude/exclude.yaml
+++ b/exclude/exclude.yaml
@@ -8,5 +8,5 @@ exclude:
     compute_environment:
       ref: aws
       name: seqera_aws_ireland_fusionv2_nvme
-      workdir: s3://seqeralabs-showcase
+      workdir: s3://seqera-showcase
       workspace: "138659136604200"

--- a/include/include.yaml
+++ b/include/include.yaml
@@ -9,7 +9,7 @@ include:
     compute_environment:
       ref: aws
       name: seqera_aws_ireland_fusionv2_nvme
-      workdir: s3://seqera-showcase
+      workdir: s3://seqera-showcase/scratch/cicd
       workspace: "138659136604200"
   - pipeline:
       name: rnaseq

--- a/include/include.yaml
+++ b/include/include.yaml
@@ -9,7 +9,7 @@ include:
     compute_environment:
       ref: aws
       name: seqera_aws_ireland_fusionv2_nvme
-      workdir: s3://seqeralabs-showcase
+      workdir: s3://seqera-showcase
       workspace: "138659136604200"
   - pipeline:
       name: rnaseq

--- a/launch_pipelines.py
+++ b/launch_pipelines.py
@@ -107,8 +107,6 @@ class LaunchConfig(pydantic.BaseModel):
         outdir = "/".join(
             [
                 self.compute_environment.workdir,
-                "results",
-                "cicd",
                 self.pipeline.name,
                 "results-test-" + date,
             ]

--- a/launch_pipelines.py
+++ b/launch_pipelines.py
@@ -107,6 +107,8 @@ class LaunchConfig(pydantic.BaseModel):
         outdir = "/".join(
             [
                 self.compute_environment.workdir,
+                "results",
+                "cicd",
                 self.pipeline.name,
                 "results-test-" + date,
             ]


### PR DESCRIPTION
Adjust work directory for CICD runs to new bucket (and prefix):
- before: `s3://seqeralabs-showcase ` 
- after: `s3://seqera-showcase/scratch/cicd` 

I added the scratch/cicd so that the bucket root is kept clean. This is both to make it easy to navigate the bucket root, but it also makes it possible to apply a cleanup policy to the CICD run outputs and scratch data without having to know the pipeline names.

The showcase bucket root should look like:

![CleanShot 2024-12-24 at 14 02 26](https://github.com/user-attachments/assets/1505b290-440a-46d9-a964-919b7530eb2b)
