### PR TITLE
Ignore studios checkpoint as string to be more fault tolerant

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ This script performs the following steps:
 - If `--delete` is enabled, it removes the pipeline if it has successfully completed.
 - If `--force` is enabled, it removes the pipeline even if it has not finished or failed.
 
+### `studios_api_test.py`
+
+This script performs the following steps:
+
+This script performs the following steps:
+
+- Queries the Seqera Platform API to retrieve information about Data Studios in selected workspaces (`--workspaces`)
+- Can filter by workspace IDs and status
+- Supports sending results to Slack
+
 ### Input YAML Files
 
 #### `pipelines`

--- a/studios_api_test.py
+++ b/studios_api_test.py
@@ -19,7 +19,6 @@ class Studio(pydantic.BaseModel):
     sessionId: str
     workspaceId: int
     workspaceName: str | None = None
-    parentCheckpoint: str | None = None
     user: dict
     name: str
     statusInfo: StudioStatus


### PR DESCRIPTION
The Studios test was failing because it was trying to parse the parentCheckpoint as a string instead of the dictionary it is. This PR just removes parentCheckpoint as an option since we aren't using it anyway.