### PR TITLE
chore: update seqerakit to v0.5.6 and tower-cli to v0.15.0

### DIFF
--- a/.github/workflows/data-studios-heartbeat-staging.yml
+++ b/.github/workflows/data-studios-heartbeat-staging.yml
@@ -40,7 +40,7 @@ jobs:
       - name: install tw cli
         run: |
           set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.10.1/tw-linux-x86_64
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
           mv tw-* tw
           chmod +x tw
           sudo mv tw /usr/local/bin/

--- a/.github/workflows/data-studios-heartbeat.yml
+++ b/.github/workflows/data-studios-heartbeat.yml
@@ -40,7 +40,7 @@ jobs:
       - name: install tw cli
         run: |
           set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.10.1/tw-linux-x86_64
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
           mv tw-* tw
           chmod +x tw
           sudo mv tw /usr/local/bin/

--- a/.github/workflows/seqera-showcase-enterprise.yml
+++ b/.github/workflows/seqera-showcase-enterprise.yml
@@ -8,71 +8,71 @@ run-name: run-pipelines
 #   remove/force: Cleanup run after completion.
 # schedule: Cron schedule to trigger runs automatically.
 on:
-  workflow_dispatch:
-    inputs:
-      dryrun:
-        description: "Dryrun (do not submit pipeline)"
-        default: false
-        type: boolean
-        required: false
-      timer:
-        description: "Environment"
-        default: delay60mins
-        type: choice
-        options:
-          - noDelay
-          - delay1mins
-          - delay5mins
-          - delay15mins
-          - delay30mins
-          - delay60mins
-          - delay120mins
-          - delay360mins
-          - delay720mins
-          - waitForReviewer
-      slack:
-        description: Slack hook
-        type: boolean
-        required: false
-        default: true
-      remove:
-        description: Delete run
-        default: true
-        type: boolean
-        required: false
-      force:
-        description: Force delete run
-        default: false
-        type: boolean
-        required: false
-      pre_run:
-        description: Pre-run command
-        default: ""
-        type: string
-        required: false
-      config:
-        description: Nextflow config to add
-        default: ""
-        type: string
-        required: false
-      launch_container:
-        description: The container to be used to run Nextflow head job
-        default: ""
-        type: string
-        required: false
-      labels:
-        description: Labels to add to the pipeline
-        default: ""
-        type: string
-        required: false
-      disable_optimization:
-        description: Disable optimizations
-        default: false
-        type: boolean
-        required: false
+    workflow_dispatch:
+        inputs:
+            dryrun:
+                description: "Dryrun (do not submit pipeline)"
+                default: false
+                type: boolean
+                required: false
+            timer:
+                description: "Environment"
+                default: delay60mins
+                type: choice
+                options:
+                    - noDelay
+                    - delay1mins
+                    - delay5mins
+                    - delay15mins
+                    - delay30mins
+                    - delay60mins
+                    - delay120mins
+                    - delay360mins
+                    - delay720mins
+                    - waitForReviewer
+            slack:
+                description: Slack hook
+                type: boolean
+                required: false
+                default: true
+            remove:
+                description: Delete run
+                default: true
+                type: boolean
+                required: false
+            force:
+                description: Force delete run
+                default: false
+                type: boolean
+                required: false
+            pre_run:
+                description: Pre-run command
+                default: ""
+                type: string
+                required: false
+            config:
+                description: Nextflow config to add
+                default: ""
+                type: string
+                required: false
+            launch_container:
+                description: The container to be used to run Nextflow head job
+                default: ""
+                type: string
+                required: false
+            labels:
+                description: Labels to add to the pipeline
+                default: ""
+                type: string
+                required: false
+            disable_optimization:
+                description: Disable optimizations
+                default: false
+                type: boolean
+                required: false
 
 env:
-  TOWER_API_ENDPOINT: ${{ secrets.STAGING_ENTERPRISE_TOWER_ACCESS_ENDPOINT }}
+    TOWER_API_ENDPOINT: ${{ secrets.STAGING_ENTERPRISE_TOWER_ACCESS_ENDPOINT }}
 
 # This workflow launches pipelines in Tower, waits for completion,
 # extracts metadata, and optionally sends Slack notifications.
@@ -84,105 +84,105 @@ env:
 # extract_metadata.py to collect metadata, sends Slack notifications
 # if configured, and deletes the workflow run if configured.
 jobs:
-  launch:
-    runs-on: ubuntu-latest
-    env:
-      TOWER_ACCESS_TOKEN: ${{ secrets.STAGING_ENTERPRISE_TOWER_ACCESS_TOKEN }}
-      PRE_RUN: ${{ github.event_name != 'workflow_dispatch' && 'true' || inputs.pre_run }}
-    steps:
-      - uses: actions/checkout@v4
+    launch:
+        runs-on: ubuntu-latest
+        env:
+            TOWER_ACCESS_TOKEN: ${{ secrets.STAGING_ENTERPRISE_TOWER_ACCESS_TOKEN }}
+            PRE_RUN: ${{ github.event_name != 'workflow_dispatch' && 'true' || inputs.pre_run }}
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: "pip"
+            - name: setup python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+                  cache: "pip"
 
-      - name: install dependencies
-        run: |
-          pip install -r requirements.txt
+            - name: install dependencies
+              run: |
+                  pip install -r requirements.txt
 
-      - name: install tw cli
-        run: |
-          set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.10.1/tw-linux-x86_64
-          mv tw-* tw
-          chmod +x tw
-          sudo mv tw /usr/local/bin/
+            - name: install tw cli
+              run: |
+                  set -euo pipefail
+                  wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+                  mv tw-* tw
+                  chmod +x tw
+                  sudo mv tw /usr/local/bin/
 
-      - name: tower check
-        run: |
-          tw --version
+            - name: tower check
+              run: |
+                  tw --version
 
-      - name: launch_pipelines
-        run: |
-          python launch_pipelines.py \
-            -l DEBUG \
-            -i \
-            pipelines/production*.yaml \
-            compute-envs/enterprise*.yaml \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '--labels "automation"' }} \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.dryrun == true) && '--dryrun' || '' }} \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_optimization == false) && '' || '--disable-optimization' }} \
-            -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
+            - name: launch_pipelines
+              run: |
+                  python launch_pipelines.py \
+                    -l DEBUG \
+                    -i \
+                    pipelines/production*.yaml \
+                    compute-envs/enterprise*.yaml \
+                    ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
+                    ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
+                    ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \
+                    ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '--labels "automation"' }} \
+                    ${{ (github.event_name == 'workflow_dispatch' && inputs.dryrun == true) && '--dryrun' || '' }} \
+                    ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_optimization == false) && '' || '--disable-optimization' }} \
+                    -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
-          path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
+            - uses: actions/upload-artifact@v4
+              with:
+                  name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
+                  path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 
-  clearup-and-delete:
-    runs-on: ubuntu-latest
-    needs: [launch]
-    environment: ${{ inputs.timer || 'delay60mins' }}
-    env:
-      TOWER_ACCESS_TOKEN: ${{ secrets.STAGING_ENTERPRISE_TOWER_ACCESS_TOKEN }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    clearup-and-delete:
+        runs-on: ubuntu-latest
+        needs: [launch]
+        environment: ${{ inputs.timer || 'delay60mins' }}
+        env:
+            TOWER_ACCESS_TOKEN: ${{ secrets.STAGING_ENTERPRISE_TOWER_ACCESS_TOKEN }}
+            SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
-          path: run_details
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/download-artifact@v4
+              with:
+                  name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
+                  path: run_details
 
-      - name: Install tw CLI
-        run: |
-          set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.9.2/tw-linux-x86_64
-          mv tw-* tw
-          chmod +x tw
-          sudo mv tw /usr/local/bin/
+            - name: Install tw CLI
+              run: |
+                  set -euo pipefail
+                  wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+                  mv tw-* tw
+                  chmod +x tw
+                  sudo mv tw /usr/local/bin/
 
-      - name: tower check
-        run: |
-          tw --version
+            - name: tower check
+              run: |
+                  tw --version
 
-      - name: setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: "pip"
+            - name: setup python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+                  cache: "pip"
 
-      - name: install dependencies
-        run: |
-          pip install -r requirements.txt
+            - name: install dependencies
+              run: |
+                  pip install -r requirements.txt
 
-      - name: finish workflow
-        run: |
-          python extract_metadata.py \
-            -l DEBUG \
-            -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
-            -i run_details/* \
-            --slack_channel ${{ secrets.SLACK_CHANNEL }} \
-            ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
-            ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
-            ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}
+            - name: finish workflow
+              run: |
+                  python extract_metadata.py \
+                    -l DEBUG \
+                    -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
+                    -i run_details/* \
+                    --slack_channel ${{ secrets.SLACK_CHANNEL }} \
+                    ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
+                    ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
+                    ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data
-          path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json
+            - uses: actions/upload-artifact@v4
+              with:
+                  name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data
+                  path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json

--- a/.github/workflows/seqera-showcase-enterprise.yml
+++ b/.github/workflows/seqera-showcase-enterprise.yml
@@ -8,71 +8,71 @@ run-name: run-pipelines
 #   remove/force: Cleanup run after completion.
 # schedule: Cron schedule to trigger runs automatically.
 on:
-    workflow_dispatch:
-        inputs:
-            dryrun:
-                description: "Dryrun (do not submit pipeline)"
-                default: false
-                type: boolean
-                required: false
-            timer:
-                description: "Environment"
-                default: delay60mins
-                type: choice
-                options:
-                    - noDelay
-                    - delay1mins
-                    - delay5mins
-                    - delay15mins
-                    - delay30mins
-                    - delay60mins
-                    - delay120mins
-                    - delay360mins
-                    - delay720mins
-                    - waitForReviewer
-            slack:
-                description: Slack hook
-                type: boolean
-                required: false
-                default: true
-            remove:
-                description: Delete run
-                default: true
-                type: boolean
-                required: false
-            force:
-                description: Force delete run
-                default: false
-                type: boolean
-                required: false
-            pre_run:
-                description: Pre-run command
-                default: ""
-                type: string
-                required: false
-            config:
-                description: Nextflow config to add
-                default: ""
-                type: string
-                required: false
-            launch_container:
-                description: The container to be used to run Nextflow head job
-                default: ""
-                type: string
-                required: false
-            labels:
-                description: Labels to add to the pipeline
-                default: ""
-                type: string
-                required: false
-            disable_optimization:
-                description: Disable optimizations
-                default: false
-                type: boolean
-                required: false
+  workflow_dispatch:
+    inputs:
+      dryrun:
+        description: "Dryrun (do not submit pipeline)"
+        default: false
+        type: boolean
+        required: false
+      timer:
+        description: "Environment"
+        default: delay60mins
+        type: choice
+        options:
+          - noDelay
+          - delay1mins
+          - delay5mins
+          - delay15mins
+          - delay30mins
+          - delay60mins
+          - delay120mins
+          - delay360mins
+          - delay720mins
+          - waitForReviewer
+      slack:
+        description: Slack hook
+        type: boolean
+        required: false
+        default: true
+      remove:
+        description: Delete run
+        default: true
+        type: boolean
+        required: false
+      force:
+        description: Force delete run
+        default: false
+        type: boolean
+        required: false
+      pre_run:
+        description: Pre-run command
+        default: ""
+        type: string
+        required: false
+      config:
+        description: Nextflow config to add
+        default: ""
+        type: string
+        required: false
+      launch_container:
+        description: The container to be used to run Nextflow head job
+        default: ""
+        type: string
+        required: false
+      labels:
+        description: Labels to add to the pipeline
+        default: ""
+        type: string
+        required: false
+      disable_optimization:
+        description: Disable optimizations
+        default: false
+        type: boolean
+        required: false
 
 env:
-    TOWER_API_ENDPOINT: ${{ secrets.STAGING_ENTERPRISE_TOWER_ACCESS_ENDPOINT }}
+  TOWER_API_ENDPOINT: ${{ secrets.STAGING_ENTERPRISE_TOWER_ACCESS_ENDPOINT }}
 
 # This workflow launches pipelines in Tower, waits for completion,
 # extracts metadata, and optionally sends Slack notifications.
@@ -84,105 +84,105 @@ env:
 # extract_metadata.py to collect metadata, sends Slack notifications
 # if configured, and deletes the workflow run if configured.
 jobs:
-    launch:
-        runs-on: ubuntu-latest
-        env:
-            TOWER_ACCESS_TOKEN: ${{ secrets.STAGING_ENTERPRISE_TOWER_ACCESS_TOKEN }}
-            PRE_RUN: ${{ github.event_name != 'workflow_dispatch' && 'true' || inputs.pre_run }}
-        steps:
-            - uses: actions/checkout@v4
+  launch:
+    runs-on: ubuntu-latest
+    env:
+      TOWER_ACCESS_TOKEN: ${{ secrets.STAGING_ENTERPRISE_TOWER_ACCESS_TOKEN }}
+      PRE_RUN: ${{ github.event_name != 'workflow_dispatch' && 'true' || inputs.pre_run }}
+    steps:
+      - uses: actions/checkout@v4
 
-            - name: setup python
-              uses: actions/setup-python@v5
-              with:
-                  python-version: "3.12"
-                  cache: "pip"
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
 
-            - name: install dependencies
-              run: |
-                  pip install -r requirements.txt
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
 
-            - name: install tw cli
-              run: |
-                  set -euo pipefail
-                  wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
-                  mv tw-* tw
-                  chmod +x tw
-                  sudo mv tw /usr/local/bin/
+      - name: install tw cli
+        run: |
+          set -euo pipefail
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+          mv tw-* tw
+          chmod +x tw
+          sudo mv tw /usr/local/bin/
 
-            - name: tower check
-              run: |
-                  tw --version
+      - name: tower check
+        run: |
+          tw --version
 
-            - name: launch_pipelines
-              run: |
-                  python launch_pipelines.py \
-                    -l DEBUG \
-                    -i \
-                    pipelines/production*.yaml \
-                    compute-envs/enterprise*.yaml \
-                    ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
-                    ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
-                    ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \
-                    ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '--labels "automation"' }} \
-                    ${{ (github.event_name == 'workflow_dispatch' && inputs.dryrun == true) && '--dryrun' || '' }} \
-                    ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_optimization == false) && '' || '--disable-optimization' }} \
-                    -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
+      - name: launch_pipelines
+        run: |
+          python launch_pipelines.py \
+            -l DEBUG \
+            -i \
+            pipelines/production*.yaml \
+            compute-envs/enterprise*.yaml \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '--labels "automation"' }} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.dryrun == true) && '--dryrun' || '' }} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_optimization == false) && '' || '--disable-optimization' }} \
+            -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 
-            - uses: actions/upload-artifact@v4
-              with:
-                  name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
-                  path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
+          path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 
-    clearup-and-delete:
-        runs-on: ubuntu-latest
-        needs: [launch]
-        environment: ${{ inputs.timer || 'delay60mins' }}
-        env:
-            TOWER_ACCESS_TOKEN: ${{ secrets.STAGING_ENTERPRISE_TOWER_ACCESS_TOKEN }}
-            SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  clearup-and-delete:
+    runs-on: ubuntu-latest
+    needs: [launch]
+    environment: ${{ inputs.timer || 'delay60mins' }}
+    env:
+      TOWER_ACCESS_TOKEN: ${{ secrets.STAGING_ENTERPRISE_TOWER_ACCESS_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/download-artifact@v4
-              with:
-                  name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
-                  path: run_details
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
+          path: run_details
 
-            - name: Install tw CLI
-              run: |
-                  set -euo pipefail
-                  wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
-                  mv tw-* tw
-                  chmod +x tw
-                  sudo mv tw /usr/local/bin/
+      - name: Install tw CLI
+        run: |
+          set -euo pipefail
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+          mv tw-* tw
+          chmod +x tw
+          sudo mv tw /usr/local/bin/
 
-            - name: tower check
-              run: |
-                  tw --version
+      - name: tower check
+        run: |
+          tw --version
 
-            - name: setup python
-              uses: actions/setup-python@v5
-              with:
-                  python-version: "3.12"
-                  cache: "pip"
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
 
-            - name: install dependencies
-              run: |
-                  pip install -r requirements.txt
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
 
-            - name: finish workflow
-              run: |
-                  python extract_metadata.py \
-                    -l DEBUG \
-                    -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
-                    -i run_details/* \
-                    --slack_channel ${{ secrets.SLACK_CHANNEL }} \
-                    ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
-                    ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
-                    ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}
+      - name: finish workflow
+        run: |
+          python extract_metadata.py \
+            -l DEBUG \
+            -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
+            -i run_details/* \
+            --slack_channel ${{ secrets.SLACK_CHANNEL }} \
+            ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
+            ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
+            ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}
 
-            - uses: actions/upload-artifact@v4
-              with:
-                  name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data
-                  path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data
+          path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json

--- a/.github/workflows/seqera-showcase-production.yml
+++ b/.github/workflows/seqera-showcase-production.yml
@@ -8,75 +8,75 @@ run-name: run-pipelines
 #   remove/force: Cleanup run after completion.
 # schedule: Cron schedule to trigger runs automatically.
 on:
-  workflow_dispatch:
-    inputs:
-      dryrun:
-        description: "Dryrun (do not submit pipeline)"
-        default: false
-        type: boolean
-        required: false
-      timer:
-        description: "Environment"
-        default: delay60mins
-        type: choice
-        options:
-          - noDelay
-          - delay1mins
-          - delay5mins
-          - delay15mins
-          - delay30mins
-          - delay60mins
-          - delay120mins
-          - delay360mins
-          - delay720mins
-          - waitForReviewer
-      slack:
-        description: Slack hook
-        type: boolean
-        required: false
-        default: true
-      remove:
-        description: Delete run
-        default: true
-        type: boolean
-        required: false
-      force:
-        description: Force delete run
-        default: false
-        type: boolean
-        required: false
-      pre_run:
-        description: Pre-run command
-        default: ""
-        type: string
-        required: false
-      config:
-        description: Nextflow config to add
-        default: ""
-        type: string
-        required: false
-      launch_container:
-        description: Nextflow launch container
-        default: ""
-        type: string
-        required: false
-      labels:
-        description: Labels to add to the pipeline
-        default: ""
-        type: string
-        required: false
-      disable_optimization:
-        description: Disable optimizations
-        default: false
-        type: boolean
-        required: false
+    workflow_dispatch:
+        inputs:
+            dryrun:
+                description: "Dryrun (do not submit pipeline)"
+                default: false
+                type: boolean
+                required: false
+            timer:
+                description: "Environment"
+                default: delay60mins
+                type: choice
+                options:
+                    - noDelay
+                    - delay1mins
+                    - delay5mins
+                    - delay15mins
+                    - delay30mins
+                    - delay60mins
+                    - delay120mins
+                    - delay360mins
+                    - delay720mins
+                    - waitForReviewer
+            slack:
+                description: Slack hook
+                type: boolean
+                required: false
+                default: true
+            remove:
+                description: Delete run
+                default: true
+                type: boolean
+                required: false
+            force:
+                description: Force delete run
+                default: false
+                type: boolean
+                required: false
+            pre_run:
+                description: Pre-run command
+                default: ""
+                type: string
+                required: false
+            config:
+                description: Nextflow config to add
+                default: ""
+                type: string
+                required: false
+            launch_container:
+                description: Nextflow launch container
+                default: ""
+                type: string
+                required: false
+            labels:
+                description: Labels to add to the pipeline
+                default: ""
+                type: string
+                required: false
+            disable_optimization:
+                description: Disable optimizations
+                default: false
+                type: boolean
+                required: false
 
-  schedule:
-    # Every 2am
-    - cron: "0 2 * * *"
+    schedule:
+        # Every 2am
+        - cron: "0 2 * * *"
 
 env:
-  TOWER_API_ENDPOINT: "https://api.cloud.seqera.io"
+    TOWER_API_ENDPOINT: "https://api.cloud.seqera.io"
 
 # This workflow launches pipelines in Tower, waits for completion,
 # extracts metadata, and optionally sends Slack notifications.
@@ -88,107 +88,107 @@ env:
 # extract_metadata.py to collect metadata, sends Slack notifications
 # if configured, and deletes the workflow run if configured.
 jobs:
-  launch:
-    runs-on: ubuntu-latest
-    env:
-      TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
-      PRE_RUN: ${{ github.event_name != 'workflow_dispatch' && 'true' || inputs.pre_run }}
-    steps:
-      - uses: actions/checkout@v4
+    launch:
+        runs-on: ubuntu-latest
+        env:
+            TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
+            PRE_RUN: ${{ github.event_name != 'workflow_dispatch' && 'true' || inputs.pre_run }}
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: "pip"
+            - name: setup python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+                  cache: "pip"
 
-      - name: install dependencies
-        run: |
-          pip install -r requirements.txt
+            - name: install dependencies
+              run: |
+                  pip install -r requirements.txt
 
-      - name: install tw cli
-        run: |
-          set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.10.1/tw-linux-x86_64
-          mv tw-* tw
-          chmod +x tw
-          sudo mv tw /usr/local/bin/
+            - name: install tw cli
+              run: |
+                  set -euo pipefail
+                  wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+                  mv tw-* tw
+                  chmod +x tw
+                  sudo mv tw /usr/local/bin/
 
-      - name: tower check
-        run: |
-          tw --version
+            - name: tower check
+              run: |
+                  tw --version
 
-      - name: launch_pipelines
-        run: |
-          python launch_pipelines.py \
-            -l DEBUG \
-            -i \
-            pipelines/production*.yaml \
-            compute-envs/production*.yaml \
-            include/*.yaml \
-            exclude/* \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '--labels "automation"' }} \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.dryrun == true) && '--dryrun' || '' }} \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_optimization == false) && '' || '--disable-optimization' }} \
-            -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
+            - name: launch_pipelines
+              run: |
+                  python launch_pipelines.py \
+                    -l DEBUG \
+                    -i \
+                    pipelines/production*.yaml \
+                    compute-envs/production*.yaml \
+                    include/*.yaml \
+                    exclude/* \
+                    ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
+                    ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
+                    ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \
+                    ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '--labels "automation"' }} \
+                    ${{ (github.event_name == 'workflow_dispatch' && inputs.dryrun == true) && '--dryrun' || '' }} \
+                    ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_optimization == false) && '' || '--disable-optimization' }} \
+                    -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
-          path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
+            - uses: actions/upload-artifact@v4
+              with:
+                  name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
+                  path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 
-  clearup-and-delete:
-    runs-on: ubuntu-latest
-    needs: [launch]
-    environment: ${{ inputs.timer || 'delay60mins' }}
-    env:
-      TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    clearup-and-delete:
+        runs-on: ubuntu-latest
+        needs: [launch]
+        environment: ${{ inputs.timer || 'delay60mins' }}
+        env:
+            TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
+            SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
-          path: run_details
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/download-artifact@v4
+              with:
+                  name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
+                  path: run_details
 
-      - name: Install tw CLI
-        run: |
-          set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.9.2/tw-linux-x86_64
-          mv tw-* tw
-          chmod +x tw
-          sudo mv tw /usr/local/bin/
+            - name: Install tw CLI
+              run: |
+                  set -euo pipefail
+                  wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+                  mv tw-* tw
+                  chmod +x tw
+                  sudo mv tw /usr/local/bin/
 
-      - name: tower check
-        run: |
-          tw --version
+            - name: tower check
+              run: |
+                  tw --version
 
-      - name: setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: "pip"
+            - name: setup python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+                  cache: "pip"
 
-      - name: install dependencies
-        run: |
-          pip install -r requirements.txt
+            - name: install dependencies
+              run: |
+                  pip install -r requirements.txt
 
-      - name: finish workflow
-        run: |
-          python extract_metadata.py \
-            -l DEBUG \
-            -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
-            -i run_details/* \
-            --slack_channel ${{ secrets.SLACK_CHANNEL }} \
-            ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
-            ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
-            ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}
+            - name: finish workflow
+              run: |
+                  python extract_metadata.py \
+                    -l DEBUG \
+                    -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
+                    -i run_details/* \
+                    --slack_channel ${{ secrets.SLACK_CHANNEL }} \
+                    ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
+                    ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
+                    ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data
-          path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json
+            - uses: actions/upload-artifact@v4
+              with:
+                  name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data
+                  path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json

--- a/.github/workflows/seqera-showcase-production.yml
+++ b/.github/workflows/seqera-showcase-production.yml
@@ -8,75 +8,75 @@ run-name: run-pipelines
 #   remove/force: Cleanup run after completion.
 # schedule: Cron schedule to trigger runs automatically.
 on:
-    workflow_dispatch:
-        inputs:
-            dryrun:
-                description: "Dryrun (do not submit pipeline)"
-                default: false
-                type: boolean
-                required: false
-            timer:
-                description: "Environment"
-                default: delay60mins
-                type: choice
-                options:
-                    - noDelay
-                    - delay1mins
-                    - delay5mins
-                    - delay15mins
-                    - delay30mins
-                    - delay60mins
-                    - delay120mins
-                    - delay360mins
-                    - delay720mins
-                    - waitForReviewer
-            slack:
-                description: Slack hook
-                type: boolean
-                required: false
-                default: true
-            remove:
-                description: Delete run
-                default: true
-                type: boolean
-                required: false
-            force:
-                description: Force delete run
-                default: false
-                type: boolean
-                required: false
-            pre_run:
-                description: Pre-run command
-                default: ""
-                type: string
-                required: false
-            config:
-                description: Nextflow config to add
-                default: ""
-                type: string
-                required: false
-            launch_container:
-                description: Nextflow launch container
-                default: ""
-                type: string
-                required: false
-            labels:
-                description: Labels to add to the pipeline
-                default: ""
-                type: string
-                required: false
-            disable_optimization:
-                description: Disable optimizations
-                default: false
-                type: boolean
-                required: false
+  workflow_dispatch:
+    inputs:
+      dryrun:
+        description: "Dryrun (do not submit pipeline)"
+        default: false
+        type: boolean
+        required: false
+      timer:
+        description: "Environment"
+        default: delay60mins
+        type: choice
+        options:
+          - noDelay
+          - delay1mins
+          - delay5mins
+          - delay15mins
+          - delay30mins
+          - delay60mins
+          - delay120mins
+          - delay360mins
+          - delay720mins
+          - waitForReviewer
+      slack:
+        description: Slack hook
+        type: boolean
+        required: false
+        default: true
+      remove:
+        description: Delete run
+        default: true
+        type: boolean
+        required: false
+      force:
+        description: Force delete run
+        default: false
+        type: boolean
+        required: false
+      pre_run:
+        description: Pre-run command
+        default: ""
+        type: string
+        required: false
+      config:
+        description: Nextflow config to add
+        default: ""
+        type: string
+        required: false
+      launch_container:
+        description: Nextflow launch container
+        default: ""
+        type: string
+        required: false
+      labels:
+        description: Labels to add to the pipeline
+        default: ""
+        type: string
+        required: false
+      disable_optimization:
+        description: Disable optimizations
+        default: false
+        type: boolean
+        required: false
 
-    schedule:
-        # Every 2am
-        - cron: "0 2 * * *"
+  schedule:
+    # Every 2am
+    - cron: "0 2 * * *"
 
 env:
-    TOWER_API_ENDPOINT: "https://api.cloud.seqera.io"
+  TOWER_API_ENDPOINT: "https://api.cloud.seqera.io"
 
 # This workflow launches pipelines in Tower, waits for completion,
 # extracts metadata, and optionally sends Slack notifications.
@@ -88,107 +88,107 @@ env:
 # extract_metadata.py to collect metadata, sends Slack notifications
 # if configured, and deletes the workflow run if configured.
 jobs:
-    launch:
-        runs-on: ubuntu-latest
-        env:
-            TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
-            PRE_RUN: ${{ github.event_name != 'workflow_dispatch' && 'true' || inputs.pre_run }}
-        steps:
-            - uses: actions/checkout@v4
+  launch:
+    runs-on: ubuntu-latest
+    env:
+      TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
+      PRE_RUN: ${{ github.event_name != 'workflow_dispatch' && 'true' || inputs.pre_run }}
+    steps:
+      - uses: actions/checkout@v4
 
-            - name: setup python
-              uses: actions/setup-python@v5
-              with:
-                  python-version: "3.12"
-                  cache: "pip"
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
 
-            - name: install dependencies
-              run: |
-                  pip install -r requirements.txt
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
 
-            - name: install tw cli
-              run: |
-                  set -euo pipefail
-                  wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
-                  mv tw-* tw
-                  chmod +x tw
-                  sudo mv tw /usr/local/bin/
+      - name: install tw cli
+        run: |
+          set -euo pipefail
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+          mv tw-* tw
+          chmod +x tw
+          sudo mv tw /usr/local/bin/
 
-            - name: tower check
-              run: |
-                  tw --version
+      - name: tower check
+        run: |
+          tw --version
 
-            - name: launch_pipelines
-              run: |
-                  python launch_pipelines.py \
-                    -l DEBUG \
-                    -i \
-                    pipelines/production*.yaml \
-                    compute-envs/production*.yaml \
-                    include/*.yaml \
-                    exclude/* \
-                    ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
-                    ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
-                    ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \
-                    ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '--labels "automation"' }} \
-                    ${{ (github.event_name == 'workflow_dispatch' && inputs.dryrun == true) && '--dryrun' || '' }} \
-                    ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_optimization == false) && '' || '--disable-optimization' }} \
-                    -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
+      - name: launch_pipelines
+        run: |
+          python launch_pipelines.py \
+            -l DEBUG \
+            -i \
+            pipelines/production*.yaml \
+            compute-envs/production*.yaml \
+            include/*.yaml \
+            exclude/* \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '--labels "automation"' }} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.dryrun == true) && '--dryrun' || '' }} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_optimization == false) && '' || '--disable-optimization' }} \
+            -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 
-            - uses: actions/upload-artifact@v4
-              with:
-                  name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
-                  path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
+          path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 
-    clearup-and-delete:
-        runs-on: ubuntu-latest
-        needs: [launch]
-        environment: ${{ inputs.timer || 'delay60mins' }}
-        env:
-            TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
-            SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  clearup-and-delete:
+    runs-on: ubuntu-latest
+    needs: [launch]
+    environment: ${{ inputs.timer || 'delay60mins' }}
+    env:
+      TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/download-artifact@v4
-              with:
-                  name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
-                  path: run_details
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
+          path: run_details
 
-            - name: Install tw CLI
-              run: |
-                  set -euo pipefail
-                  wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
-                  mv tw-* tw
-                  chmod +x tw
-                  sudo mv tw /usr/local/bin/
+      - name: Install tw CLI
+        run: |
+          set -euo pipefail
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+          mv tw-* tw
+          chmod +x tw
+          sudo mv tw /usr/local/bin/
 
-            - name: tower check
-              run: |
-                  tw --version
+      - name: tower check
+        run: |
+          tw --version
 
-            - name: setup python
-              uses: actions/setup-python@v5
-              with:
-                  python-version: "3.12"
-                  cache: "pip"
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
 
-            - name: install dependencies
-              run: |
-                  pip install -r requirements.txt
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
 
-            - name: finish workflow
-              run: |
-                  python extract_metadata.py \
-                    -l DEBUG \
-                    -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
-                    -i run_details/* \
-                    --slack_channel ${{ secrets.SLACK_CHANNEL }} \
-                    ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
-                    ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
-                    ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}
+      - name: finish workflow
+        run: |
+          python extract_metadata.py \
+            -l DEBUG \
+            -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
+            -i run_details/* \
+            --slack_channel ${{ secrets.SLACK_CHANNEL }} \
+            ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
+            ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
+            ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}
 
-            - uses: actions/upload-artifact@v4
-              with:
-                  name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data
-                  path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data
+          path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json

--- a/.github/workflows/seqera-showcase-staging.yml
+++ b/.github/workflows/seqera-showcase-staging.yml
@@ -8,75 +8,75 @@ run-name: run-pipelines
 #   remove/force: Cleanup run after completion.
 # schedule: Cron schedule to trigger runs automatically.
 on:
-  workflow_dispatch:
-    inputs:
-      dryrun:
-        description: "Dryrun (do not submit pipeline)"
-        default: false
-        type: boolean
-        required: false
-      timer:
-        description: "Environment"
-        default: delay60mins
-        type: choice
-        options:
-          - noDelay
-          - delay1mins
-          - delay5mins
-          - delay15mins
-          - delay30mins
-          - delay60mins
-          - delay120mins
-          - delay360mins
-          - delay720mins
-          - waitForReviewer
-      slack:
-        description: Slack hook
-        type: boolean
-        required: false
-        default: true
-      remove:
-        description: Delete run
-        default: true
-        type: boolean
-        required: false
-      force:
-        description: Force delete run
-        default: false
-        type: boolean
-        required: false
-      pre_run:
-        description: Pre-run command
-        default: ""
-        type: string
-        required: false
-      config:
-        description: Nextflow config to add
-        default: ""
-        type: string
-        required: false
-      launch_container:
-        description: Nextflow launch container
-        default: ""
-        type: string
-        required: false
-      labels:
-        description: Labels to add to the pipeline
-        default: ""
-        type: string
-        required: false
-      disable_optimization:
-        description: Disable optimizations
-        default: false
-        type: boolean
-        required: false
+    workflow_dispatch:
+        inputs:
+            dryrun:
+                description: "Dryrun (do not submit pipeline)"
+                default: false
+                type: boolean
+                required: false
+            timer:
+                description: "Environment"
+                default: delay60mins
+                type: choice
+                options:
+                    - noDelay
+                    - delay1mins
+                    - delay5mins
+                    - delay15mins
+                    - delay30mins
+                    - delay60mins
+                    - delay120mins
+                    - delay360mins
+                    - delay720mins
+                    - waitForReviewer
+            slack:
+                description: Slack hook
+                type: boolean
+                required: false
+                default: true
+            remove:
+                description: Delete run
+                default: true
+                type: boolean
+                required: false
+            force:
+                description: Force delete run
+                default: false
+                type: boolean
+                required: false
+            pre_run:
+                description: Pre-run command
+                default: ""
+                type: string
+                required: false
+            config:
+                description: Nextflow config to add
+                default: ""
+                type: string
+                required: false
+            launch_container:
+                description: Nextflow launch container
+                default: ""
+                type: string
+                required: false
+            labels:
+                description: Labels to add to the pipeline
+                default: ""
+                type: string
+                required: false
+            disable_optimization:
+                description: Disable optimizations
+                default: false
+                type: boolean
+                required: false
 
-  # schedule:
-  #   # Every 2am
-  #   - cron: "0 2 * * *"
+    # schedule:
+    #   # Every 2am
+    #   - cron: "0 2 * * *"
 
 env:
-  TOWER_API_ENDPOINT: ${{ secrets.STAGING_TOWER_ACCESS_ENDPOINT }}
+    TOWER_API_ENDPOINT: ${{ secrets.STAGING_TOWER_ACCESS_ENDPOINT }}
 
 # This workflow launches pipelines in Tower, waits for completion,
 # extracts metadata, and optionally sends Slack notifications.
@@ -88,104 +88,104 @@ env:
 # extract_metadata.py to collect metadata, sends Slack notifications
 # if configured, and deletes the workflow run if configured.
 jobs:
-  launch:
-    runs-on: ubuntu-latest
-    env:
-      TOWER_ACCESS_TOKEN: ${{ secrets.STAGING_TOWER_ACCESS_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
+    launch:
+        runs-on: ubuntu-latest
+        env:
+            TOWER_ACCESS_TOKEN: ${{ secrets.STAGING_TOWER_ACCESS_TOKEN }}
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: "pip"
+            - name: setup python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+                  cache: "pip"
 
-      - name: install dependencies
-        run: |
-          pip install -r requirements.txt
+            - name: install dependencies
+              run: |
+                  pip install -r requirements.txt
 
-      - name: install tw cli
-        run: |
-          set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.10.1/tw-linux-x86_64
-          mv tw-* tw
-          chmod +x tw
-          sudo mv tw /usr/local/bin/
+            - name: install tw cli
+              run: |
+                  set -euo pipefail
+                  wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+                  mv tw-* tw
+                  chmod +x tw
+                  sudo mv tw /usr/local/bin/
 
-      - name: tower check
-        run: |
-          tw --version
+            - name: tower check
+              run: |
+                  tw --version
 
-      - name: launch_pipelines
-        run: |
-          python launch_pipelines.py \
-            -l DEBUG \
-            -i \
-            pipelines/staging*.yaml \
-            compute-envs/staging*.yaml \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '--labels "automation"' }} \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.dryrun == true) && '--dryrun' || '' }} \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_optimization == false) && '' || '--disable-optimization' }} \
-            -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
+            - name: launch_pipelines
+              run: |
+                  python launch_pipelines.py \
+                    -l DEBUG \
+                    -i \
+                    pipelines/staging*.yaml \
+                    compute-envs/staging*.yaml \
+                    ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
+                    ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
+                    ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \
+                    ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '--labels "automation"' }} \
+                    ${{ (github.event_name == 'workflow_dispatch' && inputs.dryrun == true) && '--dryrun' || '' }} \
+                    ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_optimization == false) && '' || '--disable-optimization' }} \
+                    -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
-          path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
+            - uses: actions/upload-artifact@v4
+              with:
+                  name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
+                  path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 
-  clearup-and-delete:
-    runs-on: ubuntu-latest
-    needs: [launch]
-    environment: ${{ inputs.timer || 'delay60mins' }}
-    env:
-      TOWER_ACCESS_TOKEN: ${{ secrets.STAGING_TOWER_ACCESS_TOKEN }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    clearup-and-delete:
+        runs-on: ubuntu-latest
+        needs: [launch]
+        environment: ${{ inputs.timer || 'delay60mins' }}
+        env:
+            TOWER_ACCESS_TOKEN: ${{ secrets.STAGING_TOWER_ACCESS_TOKEN }}
+            SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
-          path: run_details
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/download-artifact@v4
+              with:
+                  name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
+                  path: run_details
 
-      - name: Install tw CLI
-        run: |
-          set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.9.2/tw-linux-x86_64
-          mv tw-* tw
-          chmod +x tw
-          sudo mv tw /usr/local/bin/
+            - name: Install tw CLI
+              run: |
+                  set -euo pipefail
+                  wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+                  mv tw-* tw
+                  chmod +x tw
+                  sudo mv tw /usr/local/bin/
 
-      - name: tower check
-        run: |
-          tw --version
+            - name: tower check
+              run: |
+                  tw --version
 
-      - name: setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: "pip"
+            - name: setup python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+                  cache: "pip"
 
-      - name: install dependencies
-        run: |
-          pip install -r requirements.txt
+            - name: install dependencies
+              run: |
+                  pip install -r requirements.txt
 
-      - name: finish workflow
-        run: |
-          python extract_metadata.py \
-            -l DEBUG \
-            -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
-            -i run_details/* \
-            --slack_channel ${{ secrets.SLACK_CHANNEL }} \
-            ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
-            ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
-            ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}
+            - name: finish workflow
+              run: |
+                  python extract_metadata.py \
+                    -l DEBUG \
+                    -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
+                    -i run_details/* \
+                    --slack_channel ${{ secrets.SLACK_CHANNEL }} \
+                    ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
+                    ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
+                    ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data
-          path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json
+            - uses: actions/upload-artifact@v4
+              with:
+                  name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data
+                  path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json

--- a/.github/workflows/seqera-showcase-staging.yml
+++ b/.github/workflows/seqera-showcase-staging.yml
@@ -8,75 +8,75 @@ run-name: run-pipelines
 #   remove/force: Cleanup run after completion.
 # schedule: Cron schedule to trigger runs automatically.
 on:
-    workflow_dispatch:
-        inputs:
-            dryrun:
-                description: "Dryrun (do not submit pipeline)"
-                default: false
-                type: boolean
-                required: false
-            timer:
-                description: "Environment"
-                default: delay60mins
-                type: choice
-                options:
-                    - noDelay
-                    - delay1mins
-                    - delay5mins
-                    - delay15mins
-                    - delay30mins
-                    - delay60mins
-                    - delay120mins
-                    - delay360mins
-                    - delay720mins
-                    - waitForReviewer
-            slack:
-                description: Slack hook
-                type: boolean
-                required: false
-                default: true
-            remove:
-                description: Delete run
-                default: true
-                type: boolean
-                required: false
-            force:
-                description: Force delete run
-                default: false
-                type: boolean
-                required: false
-            pre_run:
-                description: Pre-run command
-                default: ""
-                type: string
-                required: false
-            config:
-                description: Nextflow config to add
-                default: ""
-                type: string
-                required: false
-            launch_container:
-                description: Nextflow launch container
-                default: ""
-                type: string
-                required: false
-            labels:
-                description: Labels to add to the pipeline
-                default: ""
-                type: string
-                required: false
-            disable_optimization:
-                description: Disable optimizations
-                default: false
-                type: boolean
-                required: false
+  workflow_dispatch:
+    inputs:
+      dryrun:
+        description: "Dryrun (do not submit pipeline)"
+        default: false
+        type: boolean
+        required: false
+      timer:
+        description: "Environment"
+        default: delay60mins
+        type: choice
+        options:
+          - noDelay
+          - delay1mins
+          - delay5mins
+          - delay15mins
+          - delay30mins
+          - delay60mins
+          - delay120mins
+          - delay360mins
+          - delay720mins
+          - waitForReviewer
+      slack:
+        description: Slack hook
+        type: boolean
+        required: false
+        default: true
+      remove:
+        description: Delete run
+        default: true
+        type: boolean
+        required: false
+      force:
+        description: Force delete run
+        default: false
+        type: boolean
+        required: false
+      pre_run:
+        description: Pre-run command
+        default: ""
+        type: string
+        required: false
+      config:
+        description: Nextflow config to add
+        default: ""
+        type: string
+        required: false
+      launch_container:
+        description: Nextflow launch container
+        default: ""
+        type: string
+        required: false
+      labels:
+        description: Labels to add to the pipeline
+        default: ""
+        type: string
+        required: false
+      disable_optimization:
+        description: Disable optimizations
+        default: false
+        type: boolean
+        required: false
 
-    # schedule:
-    #   # Every 2am
-    #   - cron: "0 2 * * *"
+  # schedule:
+  #   # Every 2am
+  #   - cron: "0 2 * * *"
 
 env:
-    TOWER_API_ENDPOINT: ${{ secrets.STAGING_TOWER_ACCESS_ENDPOINT }}
+  TOWER_API_ENDPOINT: ${{ secrets.STAGING_TOWER_ACCESS_ENDPOINT }}
 
 # This workflow launches pipelines in Tower, waits for completion,
 # extracts metadata, and optionally sends Slack notifications.
@@ -88,104 +88,104 @@ env:
 # extract_metadata.py to collect metadata, sends Slack notifications
 # if configured, and deletes the workflow run if configured.
 jobs:
-    launch:
-        runs-on: ubuntu-latest
-        env:
-            TOWER_ACCESS_TOKEN: ${{ secrets.STAGING_TOWER_ACCESS_TOKEN }}
-        steps:
-            - uses: actions/checkout@v4
+  launch:
+    runs-on: ubuntu-latest
+    env:
+      TOWER_ACCESS_TOKEN: ${{ secrets.STAGING_TOWER_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
 
-            - name: setup python
-              uses: actions/setup-python@v5
-              with:
-                  python-version: "3.12"
-                  cache: "pip"
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
 
-            - name: install dependencies
-              run: |
-                  pip install -r requirements.txt
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
 
-            - name: install tw cli
-              run: |
-                  set -euo pipefail
-                  wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
-                  mv tw-* tw
-                  chmod +x tw
-                  sudo mv tw /usr/local/bin/
+      - name: install tw cli
+        run: |
+          set -euo pipefail
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+          mv tw-* tw
+          chmod +x tw
+          sudo mv tw /usr/local/bin/
 
-            - name: tower check
-              run: |
-                  tw --version
+      - name: tower check
+        run: |
+          tw --version
 
-            - name: launch_pipelines
-              run: |
-                  python launch_pipelines.py \
-                    -l DEBUG \
-                    -i \
-                    pipelines/staging*.yaml \
-                    compute-envs/staging*.yaml \
-                    ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
-                    ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
-                    ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \
-                    ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '--labels "automation"' }} \
-                    ${{ (github.event_name == 'workflow_dispatch' && inputs.dryrun == true) && '--dryrun' || '' }} \
-                    ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_optimization == false) && '' || '--disable-optimization' }} \
-                    -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
+      - name: launch_pipelines
+        run: |
+          python launch_pipelines.py \
+            -l DEBUG \
+            -i \
+            pipelines/staging*.yaml \
+            compute-envs/staging*.yaml \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.labels != '') && format('--labels "{0}"', inputs.labels) || '--labels "automation"' }} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.dryrun == true) && '--dryrun' || '' }} \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_optimization == false) && '' || '--disable-optimization' }} \
+            -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 
-            - uses: actions/upload-artifact@v4
-              with:
-                  name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
-                  path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
+          path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.json
 
-    clearup-and-delete:
-        runs-on: ubuntu-latest
-        needs: [launch]
-        environment: ${{ inputs.timer || 'delay60mins' }}
-        env:
-            TOWER_ACCESS_TOKEN: ${{ secrets.STAGING_TOWER_ACCESS_TOKEN }}
-            SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  clearup-and-delete:
+    runs-on: ubuntu-latest
+    needs: [launch]
+    environment: ${{ inputs.timer || 'delay60mins' }}
+    env:
+      TOWER_ACCESS_TOKEN: ${{ secrets.STAGING_TOWER_ACCESS_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/download-artifact@v4
-              with:
-                  name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
-                  path: run_details
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_launch_json
+          path: run_details
 
-            - name: Install tw CLI
-              run: |
-                  set -euo pipefail
-                  wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
-                  mv tw-* tw
-                  chmod +x tw
-                  sudo mv tw /usr/local/bin/
+      - name: Install tw CLI
+        run: |
+          set -euo pipefail
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+          mv tw-* tw
+          chmod +x tw
+          sudo mv tw /usr/local/bin/
 
-            - name: tower check
-              run: |
-                  tw --version
+      - name: tower check
+        run: |
+          tw --version
 
-            - name: setup python
-              uses: actions/setup-python@v5
-              with:
-                  python-version: "3.12"
-                  cache: "pip"
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
 
-            - name: install dependencies
-              run: |
-                  pip install -r requirements.txt
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
 
-            - name: finish workflow
-              run: |
-                  python extract_metadata.py \
-                    -l DEBUG \
-                    -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
-                    -i run_details/* \
-                    --slack_channel ${{ secrets.SLACK_CHANNEL }} \
-                    ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
-                    ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
-                    ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}
+      - name: finish workflow
+        run: |
+          python extract_metadata.py \
+            -l DEBUG \
+            -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
+            -i run_details/* \
+            --slack_channel ${{ secrets.SLACK_CHANNEL }} \
+            ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
+            ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
+            ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}
 
-            - uses: actions/upload-artifact@v4
-              with:
-                  name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data
-                  path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data
+          path: ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json

--- a/launch_pipelines.py
+++ b/launch_pipelines.py
@@ -229,6 +229,10 @@ class LaunchConfig(pydantic.BaseModel):
             args_list = parse_launch_block(args_dict)
             launched_pipeline = seqera.launch(*args_list, to_json=True)
 
+            # Parse JSON string if needed (tower-cli v0.15.0+ returns JSON string)
+            if isinstance(launched_pipeline, str):
+                launched_pipeline = json.loads(launched_pipeline)
+
             # If dryrun, return default response
             if seqera.dryrun:
                 return default_response

--- a/launch_pipelines.py
+++ b/launch_pipelines.py
@@ -238,7 +238,7 @@ class LaunchConfig(pydantic.BaseModel):
                 return default_response
 
         # If we fail to add the pipeline for a predictable reason we can log and continue
-        except seqeraplatform.ResourceCreationError as err:
+        except (seqeraplatform.CommandError, seqeraplatform.ResourceExistsError) as err:
             logging.info(
                 f"Failed to launch pipeline {run_name}. Logging and proceeding..."
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pydantic==2.10.4
 pyyaml>=6
 requests==2.32.3
-seqerakit==0.4.9
+seqerakit==0.5.6
 slack-sdk>=3.37,<4
 tabulate>=0.9.0
 types-PyYAML>=6


### PR DESCRIPTION
## Why
Keep dependencies up to date with the latest stable releases to benefit from bug fixes, improvements, and new features.

## What
- Update seqerakit from v0.4.9 to v0.5.6 in requirements.txt
- Update tower-cli from v0.9.2/v0.10.1 to v0.15.0 across all GitHub workflows
- Affected workflows:
  - seqera-showcase-staging.yml
  - seqera-showcase-production.yml
  - seqera-showcase-enterprise.yml
  - data-studios-heartbeat.yml
  - data-studios-heartbeat-staging.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)