### PR TITLE
feat: add run ID column to Slack results table

### DIFF
--- a/.github/workflows/seqera-showcase-enterprise.yml
+++ b/.github/workflows/seqera-showcase-enterprise.yml
@@ -70,6 +70,11 @@ on:
         default: false
         type: boolean
         required: false
+      slack_header:
+        description: "Custom Slack header message"
+        default: "Seqera Platform Enterprise Staging"
+        type: string
+        required: false
 
 env:
   TOWER_API_ENDPOINT: ${{ secrets.STAGING_ENTERPRISE_TOWER_ACCESS_ENDPOINT }}
@@ -177,7 +182,7 @@ jobs:
             -l DEBUG \
             -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
             -i run_details/* \
-            --slack_channel ${{ secrets.SLACK_CHANNEL }} \
+            --slack_channel ${{ secrets.SLACK_CHANNEL }}: $TOWER_API_ENDPOINT \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}

--- a/.github/workflows/seqera-showcase-production.yml
+++ b/.github/workflows/seqera-showcase-production.yml
@@ -70,6 +70,11 @@ on:
         default: false
         type: boolean
         required: false
+      slack_header:
+        description: "Custom Slack header message"
+        default: "Seqera Platform Production"
+        type: string
+        required: false
 
   schedule:
     # Every 2am
@@ -184,6 +189,7 @@ jobs:
             -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
             -i run_details/* \
             --slack_channel ${{ secrets.SLACK_CHANNEL }} \
+            --slack_header "${{ inputs.slack_header }}: $TOWER_API_ENDPOINT" \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}

--- a/.github/workflows/seqera-showcase-production.yml
+++ b/.github/workflows/seqera-showcase-production.yml
@@ -189,7 +189,7 @@ jobs:
             -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
             -i run_details/* \
             --slack_channel ${{ secrets.SLACK_CHANNEL }} \
-            --slack_header "${{ inputs.slack_header }}: $TOWER_API_ENDPOINT" \
+            --slack_header "${{ inputs.slack_header }}\nEnvironment: $TOWER_API_ENDPOINT" \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}

--- a/.github/workflows/seqera-showcase-production.yml
+++ b/.github/workflows/seqera-showcase-production.yml
@@ -189,7 +189,7 @@ jobs:
             -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
             -i run_details/* \
             --slack_channel ${{ secrets.SLACK_CHANNEL }} \
-            --slack_header "${{ inputs.slack_header }}\nEnvironment: $TOWER_API_ENDPOINT" \
+            --slack_header "${{ inputs.slack_header }}"$'\n'"Environment: $TOWER_API_ENDPOINT" \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}

--- a/.github/workflows/seqera-showcase-staging.yml
+++ b/.github/workflows/seqera-showcase-staging.yml
@@ -70,6 +70,11 @@ on:
         default: false
         type: boolean
         required: false
+      slack_header:
+        description: "Custom Slack header message"
+        default: "Seqera Platform Staging"
+        type: string
+        required: false
 
   # schedule:
   #   # Every 2am
@@ -181,6 +186,7 @@ jobs:
             -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
             -i run_details/* \
             --slack_channel ${{ secrets.SLACK_CHANNEL }} \
+            --slack_header "${{ inputs.slack_header }}: $TOWER_API_ENDPOINT" \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}

--- a/.github/workflows/seqera-showcase-staging.yml
+++ b/.github/workflows/seqera-showcase-staging.yml
@@ -186,7 +186,7 @@ jobs:
             -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
             -i run_details/* \
             --slack_channel ${{ secrets.SLACK_CHANNEL }} \
-            --slack_header "${{ inputs.slack_header }}: $TOWER_API_ENDPOINT" \
+            --slack_header "${{ inputs.slack_header }}\nEnvironment: $TOWER_API_ENDPOINT" \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}

--- a/.github/workflows/seqera-showcase-staging.yml
+++ b/.github/workflows/seqera-showcase-staging.yml
@@ -186,7 +186,7 @@ jobs:
             -o ${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}_workflow_data.json \
             -i run_details/* \
             --slack_channel ${{ secrets.SLACK_CHANNEL }} \
-            --slack_header "${{ inputs.slack_header }}\nEnvironment: $TOWER_API_ENDPOINT" \
+            --slack_header "${{ inputs.slack_header }}"$'\n'"Environment: $TOWER_API_ENDPOINT" \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.slack == true ) && '--slack' || '' }} \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.remove == true ) && '--delete' || '' }} \
             ${{ ( github.event_name != 'workflow_dispatch' || inputs.force == true ) && '--force' || '' }}

--- a/extract_metadata.py
+++ b/extract_metadata.py
@@ -447,26 +447,19 @@ def get_default_slack_header() -> str:
 
 def build_header_block(header_text: str) -> Dict[str, Any]:
     """
-    Build a Slack header block with the provided text.
+    Build a Slack section block with the provided text.
 
     Args:
-        header_text: Text to display in the header.
+        header_text: Text to display (supports emojis and markdown).
 
     Returns:
-        Dict containing Slack header block structure.
+        Dict containing Slack section block structure.
     """
-    MAX_HEADER_LENGTH = 150  # Slack's limit for header block
-
-    # Truncate if too long
-    if len(header_text) > MAX_HEADER_LENGTH:
-        header_text = header_text[:MAX_HEADER_LENGTH - 3] + "..."
-
     return {
-        "type": "header",
+        "type": "section",
         "text": {
-            "type": "plain_text",
-            "text": header_text,
-            "emoji": False
+            "type": "mrkdwn",
+            "text": header_text
         }
     }
 

--- a/extract_metadata.py
+++ b/extract_metadata.py
@@ -37,7 +37,7 @@ from argparse import Namespace
 from pathlib import Path
 from seqerakit import seqeraplatform
 from slack_sdk.web import WebClient
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 # Slack table block maximum row limit (including header row)
@@ -97,6 +97,12 @@ def parse_args() -> Namespace:
         type=str,
         help="Slack channel to send message to",
         default="C054QAK3FLZ",
+    )
+    parser.add_argument(
+        "--slack_header",
+        type=str,
+        help="Custom header message for Slack notifications. If not provided, defaults to showing Seqera Platform API URL.",
+        default=None,
     )
     return parser.parse_args()
 
@@ -427,6 +433,44 @@ def sort_workflows(workflows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return sorted(workflows, key=sort_key)
 
 
+def get_default_slack_header() -> str:
+    """
+    Build default Slack header with Seqera Platform information.
+
+    Returns:
+        Default header string with Platform API URL.
+    """
+    # Default to production endpoint if not specified (same as seqerakit/tower CLI)
+    api_endpoint = os.environ.get("TOWER_API_ENDPOINT", "https://api.cloud.seqera.io")
+    return f"Seqera Platform: {api_endpoint}"
+
+
+def build_header_block(header_text: str) -> Dict[str, Any]:
+    """
+    Build a Slack header block with the provided text.
+
+    Args:
+        header_text: Text to display in the header.
+
+    Returns:
+        Dict containing Slack header block structure.
+    """
+    MAX_HEADER_LENGTH = 150  # Slack's limit for header block
+
+    # Truncate if too long
+    if len(header_text) > MAX_HEADER_LENGTH:
+        header_text = header_text[:MAX_HEADER_LENGTH - 3] + "..."
+
+    return {
+        "type": "header",
+        "text": {
+            "type": "plain_text",
+            "text": header_text,
+            "emoji": False
+        }
+    }
+
+
 def build_table_block(parsed_data: List[Dict[str, Any]]) -> Dict[str, Any]:
     """
     Build a Slack table block to display workflows sorted by status, pipeline, compute env, and workspace.
@@ -525,6 +569,7 @@ def send_slack_message(
     data_to_send: Dict[str, str],
     filepath: Path,
     slack_channel: str,
+    slack_header: Optional[str] = None,
 ) -> None:
     """
     Send Slack message(s) with workflow metadata using table blocks and upload JSON file as threaded reply.
@@ -535,6 +580,7 @@ def send_slack_message(
         data_to_send (dict): The dictionary the name of each table element (as keys) with each field within the dictionary to send as a value.
         filepath (Path): The path to the JSON file to attach to the Slack message. Can be zipped up for convenience.
         slack_channel (str): The Slack channel to send the message to.
+        slack_header (str, optional): Custom header message for Slack notifications. If not provided, defaults to showing Seqera Platform API URL.
     Returns:
         None
     """
@@ -568,12 +614,23 @@ def send_slack_message(
     # Create fallback text with summary statistics for notifications
     fallback_text = f"Workflow Report ({summary['total']} workflows: {summary['succeeded']} ✅, {summary['failed']} ❌)"
 
+    # Determine header message
+    if slack_header is None:
+        header_message = get_default_slack_header()
+    else:
+        header_message = slack_header
+
     # Send each batch as a separate message
     for idx, batch in enumerate(workflow_batches):
         message_num = idx + 1
 
         # Build blocks for message
         blocks = []
+
+        # Add header (only on first message)
+        if message_num == 1:
+            header_block = build_header_block(header_message)
+            blocks.append(header_block)
 
         # Add part indicator if multiple messages
         if num_messages > 1:
@@ -687,6 +744,7 @@ def main() -> None:
             data_to_extract,
             zipfile_out,
             slack_channel=args.slack_channel,
+            slack_header=args.slack_header,
         )
 
     # On success, delete if pipeline succeeded

--- a/extract_metadata.py
+++ b/extract_metadata.py
@@ -480,9 +480,10 @@ def build_table_block(parsed_data: List[Dict[str, Any]]) -> Dict[str, Any]:
     # Build table rows
     rows = []
 
-    # Header row - match original column order: pipeline, workspace, computeEnv, status, workflowUrl
+    # Header row
     rows.append(
         [
+            create_table_cell_raw("Run ID"),
             create_table_cell_raw("Pipeline"),
             create_table_cell_raw("Workspace"),
             create_table_cell_raw("Compute Environment"),
@@ -496,6 +497,7 @@ def build_table_block(parsed_data: List[Dict[str, Any]]) -> Dict[str, Any]:
         status = workflow.get("status", "UNKNOWN")
         emoji = get_status_emoji(status)
         status_text = f"{emoji} {status}"
+        run_id = workflow.get("runId", "-")
         pipeline = workflow.get("pipeline", "Unknown")
         workspace = workflow.get("workspace", "-")
         compute = workflow.get("computeEnv", "-")
@@ -503,6 +505,7 @@ def build_table_block(parsed_data: List[Dict[str, Any]]) -> Dict[str, Any]:
 
         rows.append(
             [
+                create_table_cell_raw(run_id if run_id else "-"),
                 create_table_cell_raw(pipeline),
                 create_table_cell_raw(workspace),
                 create_table_cell_raw(compute),
@@ -519,6 +522,7 @@ def build_table_block(parsed_data: List[Dict[str, Any]]) -> Dict[str, Any]:
     table_block = {
         "type": "table",
         "column_settings": [
+            {"align": "left"},  # Run ID
             {"align": "left", "is_wrapped": True},  # Pipeline (allow wrapping)
             {"align": "left"},  # Workspace
             {"align": "left"},  # Compute Environment
@@ -726,6 +730,7 @@ def main() -> None:
     if args.slack:
         # Get critical info, flatten and rename to user friendly values
         data_to_extract = {
+            "runId": "workflow.id",
             "pipeline": "workflow.projectName",
             "workspace": "workflow-info.workspaceRef",
             "computeEnv": "workflow-launch.computeEnv.name",

--- a/extract_metadata.py
+++ b/extract_metadata.py
@@ -497,7 +497,7 @@ def build_table_block(parsed_data: List[Dict[str, Any]]) -> Dict[str, Any]:
         status = workflow.get("status", "UNKNOWN")
         emoji = get_status_emoji(status)
         status_text = f"{emoji} {status}"
-        run_id = workflow.get("runId", "-")
+        run_id = workflow["runId"]
         pipeline = workflow.get("pipeline", "Unknown")
         workspace = workflow.get("workspace", "-")
         compute = workflow.get("computeEnv", "-")

--- a/extract_metadata.py
+++ b/extract_metadata.py
@@ -505,7 +505,7 @@ def build_table_block(parsed_data: List[Dict[str, Any]]) -> Dict[str, Any]:
 
         rows.append(
             [
-                create_table_cell_raw(run_id if run_id else "-"),
+                create_table_cell_raw(run_id),
                 create_table_cell_raw(pipeline),
                 create_table_cell_raw(workspace),
                 create_table_cell_raw(compute),

--- a/extract_metadata.py
+++ b/extract_metadata.py
@@ -497,7 +497,7 @@ def build_table_block(parsed_data: List[Dict[str, Any]]) -> Dict[str, Any]:
         status = workflow.get("status", "UNKNOWN")
         emoji = get_status_emoji(status)
         status_text = f"{emoji} {status}"
-        run_id = workflow["runId"]
+        run_id = workflow.get("runId", "-")
         pipeline = workflow.get("pipeline", "Unknown")
         workspace = workflow.get("workspace", "-")
         compute = workflow.get("computeEnv", "-")


### PR DESCRIPTION
## Why
Run IDs weren't visible in the Slack notification table, making it harder to quickly identify and reference specific runs from the notification.

## What
- Added `runId` (from `workflow.id`) to the extracted metadata fields
- Added "Run ID" as the first column in the Slack results table
- Runs that failed to launch display "-" for the run ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)