### PR TITLE
fix: update tower-cli

### DIFF
--- a/.github/workflows/seqera-showcase-production.yml
+++ b/.github/workflows/seqera-showcase-production.yml
@@ -109,7 +109,7 @@ jobs:
       - name: install tw cli
         run: |
           set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.29.1/tw-linux-x86_64
           mv tw-* tw
           chmod +x tw
           sudo mv tw /usr/local/bin/
@@ -158,7 +158,7 @@ jobs:
       - name: Install tw CLI
         run: |
           set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.29.1/tw-linux-x86_64
           mv tw-* tw
           chmod +x tw
           sudo mv tw /usr/local/bin/


### PR DESCRIPTION
Update tower-cli to version 0.29.1 for production tests. This version fixes the issue with tw dump commands that was remediated in a previous commit.