### PR TITLE
feat(staging): add Seqera Intelligent Compute CE [COMP-1701]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ build/
 **.zip
 
 .idea/
+
+# Agent planning docs (personal, not committed)
+# Both forms: directory and bare name (the latter covers symlinks, which is
+# the preferred .plans layout when working in git worktrees).
+.plans/
+.plans

--- a/compute-envs/staging-seqera-intelligent-compute.yaml
+++ b/compute-envs/staging-seqera-intelligent-compute.yaml
@@ -1,0 +1,5 @@
+compute-envs:
+  - ref: seqera-intelligent-compute
+    name: seqera_aws_intelligent_compute_ireland
+    workdir: s3://seqera-showcase/scratch/cicd/intelligent-compute
+    workspace: "14715071736572"

--- a/scripts/provision-staging-intelligent-compute.sh
+++ b/scripts/provision-staging-intelligent-compute.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Provision the AWS Cloud compute environment with Seqera Intelligent Compute
+# (Seqera scheduler) enabled, in the staging showcase workspace.
+#
+# COMP-1701 — pairs with compute-envs/staging-seqera-intelligent-compute.yaml.
+#
+# This is a one-shot, idempotent-by-name provisioning script. The showcase
+# automation workflow itself does not create compute environments; it only
+# launches pipelines against CEs that already exist. Run this once (or after
+# the CE is deleted) before the autotest workflow can pick the CE up.
+#
+# Prerequisites:
+#   - tower-cli >= v0.27.0 (the --sched-enabled option landed in PR
+#     seqeralabs/tower-cli#610, first released in v0.27.0).
+#   - TOWER_ACCESS_TOKEN and TOWER_API_ENDPOINT exported (staging endpoint).
+#   - An AWS credentials record already present in the staging workspace.
+#     Discover its name with:
+#         tw credentials list --workspace 14715071736572
+#     and export it as CREDENTIALS_NAME below. The intent is to reuse the
+#     same AWS credentials backing the existing AWS Batch CE
+#     (seqera_aws_ireland_fusion_nvme).
+
+set -euo pipefail
+
+: "${TOWER_ACCESS_TOKEN:?TOWER_ACCESS_TOKEN must be set}"
+: "${TOWER_API_ENDPOINT:?TOWER_API_ENDPOINT must point at the staging API}"
+: "${CREDENTIALS_NAME:?CREDENTIALS_NAME must be set to the AWS credentials record in the workspace}"
+
+WORKSPACE_ID="${WORKSPACE_ID:-14715071736572}"
+CE_NAME="${CE_NAME:-seqera_aws_intelligent_compute_ireland}"
+REGION="${REGION:-eu-west-1}"
+WORK_DIR="${WORK_DIR:-s3://seqera-showcase/scratch/cicd/intelligent-compute}"
+PROVISIONING_MODEL="${PROVISIONING_MODEL:-SPOT_FIRST}"
+
+tw compute-envs add aws-cloud \
+  --workspace "${WORKSPACE_ID}" \
+  --name "${CE_NAME}" \
+  --credentials "${CREDENTIALS_NAME}" \
+  --region "${REGION}" \
+  --work-dir "${WORK_DIR}" \
+  --sched-enabled \
+  --provisioning-model "${PROVISIONING_MODEL}"


### PR DESCRIPTION
## Summary

- Adds the Seqera Intelligent Compute offering (AWS Cloud CE with the Seqera scheduler, `--sched-enabled` — see [tower-cli#610](https://github.com/seqeralabs/tower-cli/pull/610), COMP-1588) to `seqera-showcase-autotest-staging`.
- Follows the repository's existing pattern: CE is pre-provisioned in the staging Platform workspace, and only referenced by `name` from `compute-envs/staging-seqera-intelligent-compute.yaml`. The new file matches the `compute-envs/staging*.yaml` glob in `.github/workflows/seqera-showcase-staging.yml`, so the CE is automatically combined all-by-all with the staging pipelines — no workflow edit needed.
- Captures the one-shot provisioning command as `scripts/provision-staging-intelligent-compute.sh` for reproducibility.

Jira: https://seqera.atlassian.net/browse/COMP-1701

## Why a script and not workflow-time creation

`launch_pipelines.py` does not (and historically has not) created compute environments — every entry under `compute-envs/` references a CE that already exists in the workspace. Keeping that contract avoids changing the launch path and means the staging workflow does not need to be bumped off tower-cli `v0.15.0` to gain `--sched-enabled` (the launch path doesn't take that flag).

## Provisioning the CE (one-time, run by an operator)

```bash
export TOWER_ACCESS_TOKEN=...
export TOWER_API_ENDPOINT=...   # staging endpoint
export CREDENTIALS_NAME=...     # AWS creds record in workspace 14715071736572
                                # (same one backing seqera_aws_ireland_fusion_nvme;
                                #  discover with `tw credentials list --workspace 14715071736572`)
./scripts/provision-staging-intelligent-compute.sh
```

Defaults baked into the script (overridable via env vars):

| Variable | Default |
| --- | --- |
| `WORKSPACE_ID` | `14715071736572` |
| `CE_NAME` | `seqera_aws_intelligent_compute_ireland` |
| `REGION` | `eu-west-1` |
| `WORK_DIR` | `s3://seqera-showcase/scratch/cicd/intelligent-compute` |
| `PROVISIONING_MODEL` | `SPOT_FIRST` |

## Test plan

- [ ] Run `scripts/provision-staging-intelligent-compute.sh` once against staging with `CREDENTIALS_NAME` set. Confirm the CE appears in workspace `14715071736572` and reaches AVAILABLE.
- [ ] Manually trigger `seqera-showcase-autotest-staging`. Confirm the new CE appears in the launched-runs JSON artifact alongside the existing AWS/GCP/Azure/Slurm/Seqera-Compute lanes.
- [ ] Confirm the staging pipelines (`hello`, `rnaseq`, `viralrecon-illumina`, `viralrecon-nanopore`, `sarek`) all complete on the new CE.

## Out of scope

- Production rollout (`compute-envs/production-seqera-intelligent-compute.yaml` + production provisioning) — deferred until staging coverage is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)