### PR TITLE
fix: bump tw CLI to v0.31.0 across all workflows

### DIFF
--- a/.github/workflows/data-studios-heartbeat-staging.yml
+++ b/.github/workflows/data-studios-heartbeat-staging.yml
@@ -40,7 +40,7 @@ jobs:
       - name: install tw cli
         run: |
           set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.31.0/tw-linux-x86_64
           mv tw-* tw
           chmod +x tw
           sudo mv tw /usr/local/bin/

--- a/.github/workflows/data-studios-heartbeat.yml
+++ b/.github/workflows/data-studios-heartbeat.yml
@@ -40,7 +40,7 @@ jobs:
       - name: install tw cli
         run: |
           set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.31.0/tw-linux-x86_64
           mv tw-* tw
           chmod +x tw
           sudo mv tw /usr/local/bin/

--- a/.github/workflows/seqera-showcase-enterprise.yml
+++ b/.github/workflows/seqera-showcase-enterprise.yml
@@ -105,7 +105,7 @@ jobs:
       - name: install tw cli
         run: |
           set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.31.0/tw-linux-x86_64
           mv tw-* tw
           chmod +x tw
           sudo mv tw /usr/local/bin/
@@ -152,7 +152,7 @@ jobs:
       - name: Install tw CLI
         run: |
           set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.31.0/tw-linux-x86_64
           mv tw-* tw
           chmod +x tw
           sudo mv tw /usr/local/bin/

--- a/.github/workflows/seqera-showcase-production.yml
+++ b/.github/workflows/seqera-showcase-production.yml
@@ -109,7 +109,7 @@ jobs:
       - name: install tw cli
         run: |
           set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.29.1/tw-linux-x86_64
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.31.0/tw-linux-x86_64
           mv tw-* tw
           chmod +x tw
           sudo mv tw /usr/local/bin/
@@ -158,7 +158,7 @@ jobs:
       - name: Install tw CLI
         run: |
           set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.29.1/tw-linux-x86_64
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.31.0/tw-linux-x86_64
           mv tw-* tw
           chmod +x tw
           sudo mv tw /usr/local/bin/

--- a/.github/workflows/seqera-showcase-staging.yml
+++ b/.github/workflows/seqera-showcase-staging.yml
@@ -108,7 +108,7 @@ jobs:
       - name: install tw cli
         run: |
           set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.31.0/tw-linux-x86_64
           mv tw-* tw
           chmod +x tw
           sudo mv tw /usr/local/bin/
@@ -155,7 +155,7 @@ jobs:
       - name: Install tw CLI
         run: |
           set -euo pipefail
-          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.15.0/tw-linux-x86_64
+          wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.31.0/tw-linux-x86_64
           mv tw-* tw
           chmod +x tw
           sudo mv tw /usr/local/bin/


### PR DESCRIPTION
## Summary

- Bumps the `tw` CLI download in every workflow to **v0.31.0**.
- Aligns `seqera-showcase-production.yml` (was v0.29.1) and the other five workflow files (still on v0.15.0) onto a single version.

## Why

The staging run [25724525353](https://github.com/seqeralabs/showcase-automation/actions/runs/25724525353/job/75534269132) failed in the `finish workflow` step with:

```
tw -o json runs dump -id k4MvMy4IBS51a -o tmp.k4MvMy4IBS51a.tar.gz -w 14715071736572
…
ERROR: Unexpected error while processing request - Error ID: 2N5X56V80d5z6aAwO7OiWL
```

v0.15.0 (mid-2024) predates tower-cli#520 (Jun 2025) — *"fix: nullpointerexception when running runs dump for a nextflow -with-tower run"* — which handles null launch fields in JSON output and catches exceptions while downloading workflow logs. The runs in this pipeline are launched via `tw launch` (`-with-tower`), which is exactly the path that fix addresses.

The CLI flag layout (`-o json runs dump -id … -o … -w …`) is unchanged between v0.15.0 and v0.31.0, so no Python changes are needed.

## Test plan

- [ ] Trigger `seqera-showcase-autotest-staging` via `workflow_dispatch` and confirm the `clearup-and-delete` job's `finish workflow` step succeeds end-to-end (runs dump + Slack post + delete).
- [ ] Confirm `tower check` step prints `Tower CLI version 0.31.0` in both jobs.