### PR TITLE
feat: Add sched-staging pipelines to staging workflow [COMP-1702]

### DIFF
--- a/.github/workflows/seqera-showcase-staging.yml
+++ b/.github/workflows/seqera-showcase-staging.yml
@@ -128,7 +128,9 @@ jobs:
             -l DEBUG \
             -i \
             pipelines/staging*.yaml \
+            pipelines/sched-staging*.yaml \
             compute-envs/staging*.yaml \
+            compute-envs/sched-staging*.yaml \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \


### PR DESCRIPTION
## Summary

- Extends the `seqera-showcase-staging` workflow to also launch sched-staging pipelines alongside the existing staging ones
- Adds `pipelines/sched-staging*.yaml` and `compute-envs/sched-staging*.yaml` glob patterns to the `launch_pipelines` step

## Test plan

- [x] Trigger the staging workflow manually (`workflow_dispatch`) and verify sched-staging pipelines are launched

🤖 Generated with [Claude Code](https://claude.com/claude-code)