### PR TITLE
chore: add viralrecon-nanopore execution to test

### DIFF
--- a/pipelines/sched-staging-nf-core-pipelines.yaml
+++ b/pipelines/sched-staging-nf-core-pipelines.yaml
@@ -9,3 +9,8 @@ pipelines:
     latest: true
     profiles:
       - test
+  - name: viralrecon-nanopore
+    url: nf-core-viralrecon-nanopore-staging
+    latest: true
+    profiles:
+      - test


### PR DESCRIPTION
Run viralrecon-nanopore pipelines using intelligent compute executor during staging battery test.