### PR TITLE
feat(workflow): add daily schedule trigger to sched-staging

### DIFF
--- a/.github/workflows/seqera-showcase-sched-staging.yml
+++ b/.github/workflows/seqera-showcase-sched-staging.yml
@@ -75,10 +75,8 @@ on:
         default: "Seqera Platform Staging"
         type: string
         required: false
-
-        # schedule:
-        #   # Every 2am
-        #   - cron: "0 2 * * *"
+  schedule:
+    - cron: "0 0 * * *"
 
 env:
   TOWER_API_ENDPOINT: ${{ secrets.STAGING_TOWER_ACCESS_ENDPOINT }}

--- a/.github/workflows/seqera-showcase-sched-staging.yml
+++ b/.github/workflows/seqera-showcase-sched-staging.yml
@@ -76,7 +76,7 @@ on:
         type: string
         required: false
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 12 * * *"
 
 env:
   TOWER_API_ENDPOINT: ${{ secrets.STAGING_TOWER_ACCESS_ENDPOINT }}


### PR DESCRIPTION
## Summary

- Adds a `schedule` cron trigger (`0 12 * * *` — 12 mid day UTC) to `seqera-showcase-sched-staging.yml` so the workflow runs daily without manual dispatch
- Removes the misplaced commented-out schedule block that was incorrectly nested inside `workflow_dispatch.inputs` (would have been invalid YAML if uncommented)

## Behaviour on scheduled runs

All `workflow_dispatch` input conditionals already fall back safely when triggered by the scheduler:
- `slack` → true
- `remove` → true
- `force` → false
- `timer` → `delay60mins` (via `inputs.timer || 'delay60mins'`)

No logic changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)