### PR TITLE
fix: Exclude nf-core pipelines from azure_cloud compute environments

### DIFF
--- a/.github/workflows/seqera-showcase-enterprise.yml
+++ b/.github/workflows/seqera-showcase-enterprise.yml
@@ -126,6 +126,7 @@ jobs:
             -i \
             pipelines/production*.yaml \
             compute-envs/enterprise*.yaml \
+            exclude/* \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \

--- a/.github/workflows/seqera-showcase-staging.yml
+++ b/.github/workflows/seqera-showcase-staging.yml
@@ -130,6 +130,7 @@ jobs:
             pipelines/staging*.yaml \
             compute-envs/staging*.yaml \
             compute-envs/sched-staging*.yaml \
+            exclude/* \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.pre_run != '') && format('--pre_run "{0}"', inputs.pre_run) || ''}} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.config != '') && format('--config "{0}"', inputs.config) || '' }} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.launch_container) && format('--launch-container "{0}"', inputs.launch_container) || '' }} \

--- a/exclude/exclude.yaml
+++ b/exclude/exclude.yaml
@@ -10,3 +10,50 @@ exclude:
       name: seqera_aws_ireland_fusionv2_nvme
       workdir: s3://seqera-showcase/scratch/cicd
       workspace: ""
+  # Do not run any nf-core pipeline on azure_cloud compute environments.
+  # These exclusions should be lifted once COMP-1933 is delivered:
+  # https://seqera.atlassian.net/browse/COMP-1933
+  - pipeline:
+      name: rnaseq
+      url: nf-core-rnaseq
+      latest: true
+      profiles:
+        - test
+    compute_environment:
+      ref: azure-cloud
+      name: seqera_azure_cloud
+      workdir: az://seqeralabs-showcase
+      workspace: ""
+  - pipeline:
+      name: viralrecon-illumina
+      url: nf-core-viralrecon-illumina
+      latest: true
+      profiles:
+        - test
+    compute_environment:
+      ref: azure-cloud
+      name: seqera_azure_cloud
+      workdir: az://seqeralabs-showcase
+      workspace: ""
+  - pipeline:
+      name: viralrecon-nanopore
+      url: nf-core-viralrecon-nanopore
+      latest: true
+      profiles:
+        - test
+    compute_environment:
+      ref: azure-cloud
+      name: seqera_azure_cloud
+      workdir: az://seqeralabs-showcase
+      workspace: ""
+  - pipeline:
+      name: sarek
+      url: nf-core-sarek
+      latest: true
+      profiles:
+        - test
+    compute_environment:
+      ref: azure-cloud
+      name: seqera_azure_cloud
+      workdir: az://seqeralabs-showcase
+      workspace: ""


### PR DESCRIPTION
## Summary

Stops any nf-core pipeline from being launched on the `seqera_azure_cloud` compute environment across **staging, production and enterprise**.

## Changes

- **`exclude/exclude.yaml`** — added exclude entries for each nf-core pipeline (`rnaseq`, `viralrecon-illumina`, `viralrecon-nanopore`, `sarek`) targeting the `seqera_azure_cloud` CE. Exclusion matching keys on pipeline `name` + compute-env `name`, both of which are identical across environments, so one entry per pipeline covers all three.
- **`.github/workflows/seqera-showcase-staging.yml`** and **`.github/workflows/seqera-showcase-enterprise.yml`** — pass `exclude/*` to `launch_pipelines.py`. These workflows target the azure_cloud CE but previously did not load the exclude file (only the production / sched-production workflows did), so the exclusions would otherwise have had no effect there.

The sched-staging / sched-production workflows only use AWS `sched-*` CEs (no azure_cloud), so they were left unchanged.

## Verification

Dry-run of `read_yaml` over each environment's input set confirms all 4 nf-core pipelines are removed from `seqera_azure_cloud`, with only the non-nf-core `hello` pipeline remaining on that CE.

## Note

These exclusions should be lifted once [COMP-1933](https://seqera.atlassian.net/browse/COMP-1933) is delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[COMP-1933]: https://seqera.atlassian.net/browse/COMP-1933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ